### PR TITLE
feat: Include score matching in end-to-end tests.

### DIFF
--- a/examples/pounce_sm.py
+++ b/examples/pounce_sm.py
@@ -9,6 +9,7 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
+
 import numpy as np
 import matplotlib.pyplot as plt
 import imageio
@@ -16,69 +17,102 @@ import os
 from sklearn.decomposition import PCA
 import jax.numpy as jnp
 from jax.random import rademacher
+from pathlib import Path
 
 from coreax.kernel import rbf_kernel, median_heuristic, stein_kernel_pc_imq_element
 from coreax.kernel_herding import stein_kernel_herding_block
 from coreax.score_matching import sliced_score_matching
+from coreax.metrics import mmd_block
 
-# path to directory containing video as sequence of images
-dir = "./examples/data/pounce"
-fn = "pounce.gif"
-os.makedirs(f"{dir}/coreset", exist_ok=True)
 
-# read in as video. Frame 0 is missing A from RGBA.
-Y_ = np.array(imageio.v2.mimread(f"{dir}/{fn}")[1:])
-Y = Y_.reshape(Y_.shape[0], -1)
+def main(directory: Path = "./examples/data/pounce"):
+    """
+    Run the 'pounce' example for video sampling with score matching rather than a
+    pre-specified kernel.
 
-# run PCA to reduce the dimension of the images whilst minimising effects on some of the
-# statistical properties, i.e. variance.
-p = 25
-pca = PCA(p)
-X = pca.fit_transform(Y)
+    Args:
+        directory: path to directory containing input video.
 
-# request a 10 frame summary of the video
-C = 10
+    Returns:
+        coreset MMD, random sample MMD
 
-# set the bandwidth parameter of the underlying RBF kernel
-N = min(X.shape[0], 1000)
-idx = np.random.choice(X.shape[0], N, replace=False)
-nu = median_heuristic(X[idx])
+    """
 
-# define the kernel
-k = lambda x, y: rbf_kernel(x, y, jnp.float32(nu) ** 2) / (nu * jnp.sqrt(2.0 * jnp.pi))
-weighted = True
+    # path to directory containing video as sequence of images
+    fn = "pounce.gif"
+    os.makedirs(directory / "coreset_sm", exist_ok=True)
 
-# learn a score function
-score_function = sliced_score_matching(
-    X, rademacher, use_analytic=True, epochs=100, L=100, sigma=1.0
-)
+    # read in as video. Frame 0 is missing A from RGBA.
+    Y_ = np.array(imageio.v2.mimread(f"{directory}/{fn}")[1:])
+    Y = Y_.reshape(Y_.shape[0], -1)
 
-# run Stein kernel herding in block mode to avoid GPU memory issues
-coreset, Kc, Kbar = stein_kernel_herding_block(
-    X, C, stein_kernel_pc_imq_element, score_function, nu=nu, max_size=1000, sm=True
-)
+    # run PCA to reduce the dimension of the images whilst minimising effects on some of the statistical
+    # properties, i.e. variance.
+    p = 25
+    pca = PCA(p)
+    X = pca.fit_transform(Y)
 
-# sort the coreset ready for producing the output video
-coreset = jnp.sort(coreset)
-print("Coreset:", coreset)
+    # request a 10 frame summary of the video
+    C = 10
 
-# Save a new video. Y_ is the original sequence with dimensions preserved
-coreset_images = Y_[coreset]
-imageio.mimsave(f"{dir}/coreset/coreset_sm.gif", coreset_images)
+    # set the bandwidth parameter of the underlying RBF kernel
+    N = min(X.shape[0], 1000)
+    idx = np.random.choice(X.shape[0], N, replace=False)
+    nu = median_heuristic(X[idx])
 
-# plot to visualise which frames were chosen from the sequence action frames are where
-# the "pounce" occurs
-action_frames = np.arange(63, 85)
-x = np.arange(N)
-y = np.zeros(N)
-y[coreset] = 1.0
-z = np.zeros(N)
-z[jnp.intersect1d(coreset, action_frames)] = 1.0
-plt.figure(figsize=(20, 3))
-plt.bar(x, y, alpha=0.5)
-plt.bar(x, z)
-plt.xlabel("Frame")
-plt.ylabel("Chosen")
-plt.tight_layout()
-plt.savefig(f"{dir}/coreset/frames_sm.png")
-plt.close()
+    # learn a score function
+    score_function = sliced_score_matching(
+        X, rademacher, use_analytic=True, epochs=100, L=100, sigma=1.0
+    )
+
+    # run Stein kernel herding in block mode to avoid GPU memory issues
+    coreset, Kc, Kbar = stein_kernel_herding_block(
+        X, C, stein_kernel_pc_imq_element, score_function, nu=nu, max_size=1000, sm=True
+    )
+
+    # sort the coreset ready for producing the output video
+    coreset = jnp.sort(coreset)
+    print("Coreset:", coreset)
+
+    # define a reference kernel to use for comparisons of MMD. We'll use an RBF
+    def k(x, y): return rbf_kernel(x, y, jnp.float32(nu)**2) / \
+        (nu * jnp.sqrt(2. * jnp.pi))
+
+    # compute the MMD between X and the coreset
+    m = mmd_block(X, X[coreset], k, max_size=1000)
+
+    # get a random sample of points to compare against
+    rsample = np.random.choice(N, size=C, replace=False)
+    # compute the MMD between X and the random sample
+    rm = mmd_block(X, X[rsample], k, max_size=1000).item()
+
+    # print the MMDs
+    print(f"Random MMD: {rm}")
+    print(f"Coreset MMD: {m}")
+
+    # Save a new video. Y_ is the original sequence with dimensions preserved
+    coreset_images = Y_[coreset]
+    imageio.mimsave(directory / "coreset_sm" / "coreset_sm.gif", coreset_images)
+
+    # plot to visualise which frames were chosen from the sequence action frames are where
+    # the "pounce" occurs
+    action_frames = np.arange(63, 85)
+    x = np.arange(N)
+    y = np.zeros(N)
+    y[coreset] = 1.0
+    z = np.zeros(N)
+    z[jnp.intersect1d(coreset, action_frames)] = 1.0
+    plt.figure(figsize=(20, 3))
+    plt.bar(x, y, alpha=0.5)
+    plt.bar(x, z)
+    plt.xlabel("Frame")
+    plt.ylabel("Chosen")
+    plt.tight_layout()
+    plt.savefig(directory / "coreset_sm" / "frames_sm.png")
+    plt.close()
+
+    return m, rm
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/weighted_herding_sm.py
+++ b/examples/weighted_herding_sm.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 import jax.numpy as jnp
 from jax.random import normal
 from sklearn.datasets import make_blobs
+from pathlib import Path
 
 from coreax.weights import qp
 from coreax.kernel import rbf_kernel, median_heuristic, stein_kernel_pc_imq_element
@@ -22,82 +23,95 @@ from coreax.score_matching import sliced_score_matching
 
 import numpy as np
 
-# create some data. Here we'll use 10,000 points in 2D from 6 distinct clusters. 2D for
-# plotting below.
-N = 10000
-X, _ = make_blobs(N, n_features=2, centers=6, random_state=32)
 
-# ask for 100 coreset points
-C = 100
+def main(out_path: Path = None, weighted: bool = True):
+    """
+    Run the 'weighted_herding' example for weighted and unweighted herding.
 
-# set the bandwidth parameter of the kernel using a median heuristic derived from at
-# most 1000 random samples in the data.
-n = min(N, 1000)
-idx = np.random.choice(N, n, replace=False)
-nu = median_heuristic(X[idx])
+    Args:
+        out_path: path to save output to, if not None. Default None.
+        weighted: boolean flag for whether to use weighted or unweighted herding
 
-# define a kernel. We'll use an RBF
+    Returns:
+        coreset MMD, random sample MMD
+
+    """
+    # create some data. Here we'll use 10,000 points in 2D from 6 distinct clusters. 2D for
+    # plotting below.
+    N = 10000
+    X, _ = make_blobs(N, n_features=2, centers=6, random_state=32)
+
+    # ask for 100 coreset points
+    C = 100
+
+    # set the bandwidth parameter of the kernel using a median heuristic derived from at
+    # most 1000 random samples in the data.
+    n = min(N, 1000)
+    idx = np.random.choice(N, n, replace=False)
+    nu = median_heuristic(X[idx])
+
+    # define a kernel. We'll use an RBF
+    def k(x, y):
+        return rbf_kernel(x, y, jnp.float32(nu) ** 2) / (nu * jnp.sqrt(2.0 * jnp.pi))
+
+    # learn a score function with normal random variables, which use the analytic form of
+    # the loss
+    score_function = sliced_score_matching(
+        X, normal, use_analytic=True, epochs=100, sigma=10.0
+    )
+
+    # Find a C-sized coreset using -- in this case -- Stein kernel herding (block mode).
+    # Stein kernel herding uses the Stein kernel derived from the RBF above. Block mode
+    # processes the Gram matrix in blocks to avoid GPU memory issues. rbf_grad_log_f_X is
+    # the score function derived from sliced score matching above. max_size sets the
+    # block processing size
+
+    # returns the indices for the coreset points, the coreset Gram matrix (Kc) and the
+    # coreset Gram mean (Kbar)
+    coreset, Kc, Kbar = stein_kernel_herding_block(
+        X, C, stein_kernel_pc_imq_element, score_function, nu=nu, max_size=1000, sm=True
+    )
+
+    # get a random sample of points to compare against
+    rsample = np.random.choice(N, size=C, replace=False)
+
+    if weighted:
+        # find the weights. Solves a QP
+        weights = qp(Kc + 1e-10, Kbar)
+        # compute the MMD between X and the coreset, weighted version
+        m = mmd_weight_block(X, X[coreset], jnp.ones(N), weights, k, max_size=1000)
+    else:
+        # equal weights
+        weights = jnp.ones(C)
+        # compute the MMD between X and the coreset, unweighted version
+        m = mmd_block(X, X[coreset], k, max_size=1000)
+
+    # compute the MMD between X and the random sample
+    rm = mmd_block(X, X[rsample], k, max_size=1000)
+
+    # produce some scatter plots
+    plt.scatter(X[:, 0], X[:, 1], s=2.0, alpha=0.1)
+    plt.scatter(X[coreset, 0], X[coreset, 1], s=weights * 1000, color="red")
+    plt.axis("off")
+    plt.title("Stein kernel herding, m=%d, MMD=%.6f" % (C, m))
+    plt.show()
+
+    plt.scatter(X[:, 0], X[:, 1], s=2.0, alpha=0.1)
+    plt.scatter(X[rsample, 0], X[rsample, 1], s=10, color="red")
+    plt.title("Random, m=%d, MMD=%.6f" % (C, rm))
+    plt.axis("off")
+
+    if out_path is not None:
+        plt.savefig(out_path)
+
+    plt.show()
+
+    # print the MMDs
+    print(f"Random MMD: {rm}")
+    print(f"Coreset MMD: {m}")
+
+    return m, rm
 
 
-def k(x, y):
-    return rbf_kernel(x, y, jnp.float32(nu) ** 2) / (nu * jnp.sqrt(2.0 * jnp.pi))
-
-
-# turn the coreset weights on or off. If on, a quadratic program is invoked to solve the
-# weights' vector. This buys some increase in integration error, but at a computational
-# cost. Likely to most effective in lower dimensions.
-weighted = True
-
-# learn a score function with normal random variables, which use the analytic form of
-# the loss
-score_function = sliced_score_matching(
-    X, normal, use_analytic=True, epochs=100, sigma=10.0
-)
-
-# Find a C-sized coreset using -- in this case -- Stein kernel herding (block mode).
-# Stein kernel herding uses the Stein kernel derived from the RBF above. Block mode
-# processes the Gram matrix in blocks to avoid GPU memory issues. rbf_grad_log_f_X is
-# the score function derived from a KDE. This could be replaced by any score-function
-# approximation, e.g. score matching. max_size sets the block processing size
-
-# returns the indices for the coreset points, the coreset Gram matrix (Kc) and the
-# coreset Gram mean (Kbar)
-coreset, Kc, Kbar = stein_kernel_herding_block(
-    X, C, stein_kernel_pc_imq_element, score_function, nu=nu, max_size=1000, sm=True
-)
-
-# get a random sample of points to compare against
-rsample = np.random.choice(N, size=C, replace=False)
-
-if weighted:
-    # find the weights. Solves a QP
-    weights = qp(Kc + 1e-10, Kbar)
-    # compute the MMD between X and the coreset, weighted version
-    m = mmd_weight_block(X, X[coreset], jnp.ones(N), weights, k, max_size=1000)
-else:
-    # equal weights
-    weights = jnp.ones(C)
-    # compute the MMD between X and the coreset, unweighted version
-    m = mmd_block(X, X[coreset], k, max_size=1000)
-
-# compute the MMD between X and the random sample
-rm = mmd_block(X, X[rsample], k, max_size=1000)
-
-# produce some scatter plots
-plt.scatter(X[:, 0], X[:, 1], s=2.0, alpha=0.1)
-plt.scatter(X[coreset, 0], X[coreset, 1], s=weights * 1000, color="red")
-plt.axis("off")
-plt.title("Stein kernel herding, m=%d, MMD=%.6f" % (C, m))
-plt.show()
-
-plt.scatter(X[:, 0], X[:, 1], s=2.0, alpha=0.1)
-plt.scatter(X[rsample, 0], X[rsample, 1], s=10, color="red")
-plt.title("Random, m=%d, MMD=%.6f" % (C, rm))
-plt.axis("off")
-plt.show()
-
-# print the MMDs
-print("Random")
-print(rm)
-print("Coreset")
-print(m)
+if __name__ == '__main__':
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -18,7 +18,9 @@ from unittest.mock import patch, call
 
 from examples.david import main as david_main
 from examples.pounce import main as pounce_main
+from examples.pounce_sm import main as pounce_sm_main
 from examples.weighted_herding import main as weighted_herding_main
+from examples.weighted_herding_sm import main as weighted_herding_sm_main
 
 
 class TestExamples(unittest.TestCase):
@@ -80,6 +82,33 @@ class TestExamples(unittest.TestCase):
             self.assertLess(mmd_coreset, mmd_random,
                             msg="MMD for random sampling was unexpectedly lower than coreset MMD")
 
+    def test_pounce_sm(self):
+        """
+        Test pounce_sm.py example
+
+        An end-to-end test to check pounce_sm.py runs without error, generates output, and has coreset MMD
+        better than MMD from random sampling.
+        """
+
+        directory = Path.cwd().parent / Path("examples/data/pounce")
+
+        # delete output files if already present
+        out_dir = directory / "coreset_sm"
+        if out_dir.exists():
+            for sub in out_dir.iterdir():
+                if sub.name in {"coreset_sm.gif", "frames_sm.png"}:
+                    sub.unlink()
+
+        with patch("builtins.print"):
+            # run pounce_sm.py
+            mmd_coreset, mmd_random = pounce_sm_main(directory=directory)
+
+            self.assert_is_file(directory / Path("coreset_sm/coreset_sm.gif"))
+            self.assert_is_file(directory / Path("coreset_sm/frames_sm.png"))
+
+            self.assertLess(mmd_coreset, mmd_random,
+                            msg="MMD for random sampling was unexpectedly lower than coreset MMD")
+
     def test_weighted_herding(self):
         """
         Test weighted_herding.py example
@@ -110,6 +139,44 @@ class TestExamples(unittest.TestCase):
                 # run weighted herding example
                 outpath = Path(tmp_dir) / "unweighted_herding.png"
                 mmd_coreset, mmd_random = weighted_herding_main(out_path=outpath, weighted=False)
+
+                mock_show.assert_has_calls([call(), call()])
+
+                self.assert_is_file(outpath)
+
+                self.assertLess(mmd_coreset, mmd_random,
+                                msg="MMD for random sampling was unexpectedly lower than coreset MMD")
+
+    def test_weighted_herding_sm(self):
+        """
+        Test weighted_herding_sm.py example
+
+        An end-to-end test to check weighted_herding_sm.py runs without error, generates output, and has coreset
+        MMD better than MMD from random sampling.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp_dir, \
+                patch("builtins.print"), \
+                patch("matplotlib.pyplot.show") as mock_show:
+
+            with self.subTest(msg="Weighted herding (score matching)"):
+
+                # run weighted herding example
+                outpath = Path(tmp_dir) / "weighted_herding_sm.png"
+                mmd_coreset, mmd_random = weighted_herding_sm_main(out_path=outpath, weighted=True)
+
+                mock_show.assert_has_calls([call(), call()])
+
+                self.assert_is_file(outpath)
+
+                self.assertLess(mmd_coreset, mmd_random,
+                                msg="MMD for random sampling was unexpectedly lower than coreset MMD")
+
+            with self.subTest(msg="Unweighted herding (score matching)"):
+
+                # run weighted herding example
+                outpath = Path(tmp_dir) / "unweighted_herding_sm.png"
+                mmd_coreset, mmd_random = weighted_herding_sm_main(out_path=outpath, weighted=False)
 
                 mock_show.assert_has_calls([call(), call()])
 


### PR DESCRIPTION
Refs: #96

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context. 
-->

The two end-to-end tests for score matching, `pounce_sm.py` and `weighted_herding_sm.py` are now included in the end-to-end test script.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

The end-to-end test script has been run several times with the new tests, and passed each time.

### Does this PR introduce a breaking change? 
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
