### PR TITLE
Feature/take optional kernel_mean_row_sum in refine() (new)

### DIFF
--- a/coreax/refine.py
+++ b/coreax/refine.py
@@ -87,7 +87,11 @@ class Refine(ABC):
         self.approximator = approximator
 
     @abstractmethod
-    def refine(self, data_reduction: DataReduction) -> None:
+    def refine(
+        self,
+        data_reduction: DataReduction,
+        kernel_mean_row_sum: ArrayLike | None = None,
+    ) -> None:
         r"""
         Compute the refined coreset, of ``m`` points in ``d`` dimensions.
 
@@ -98,6 +102,10 @@ class Refine(ABC):
         :param data_reduction: :class:`~coreax.reduction.DataReduction` object with
             :math:`n \times d` original data, :math:`m` coreset point indices, coreset
             and kernel object
+        :param kernel_mean_row_sum: (Optional) Mean vector over rows for the Gram matrix,
+            a :math:`1 \times n` array. If this variable has been pre-calculated, pass
+            it here to reduce computational load. If this variable is passed,
+            `self.approximate_kernel_row_sum` is ignored.
         :return: Nothing
         """
 
@@ -138,7 +146,11 @@ class RefineRegular(Refine):
     for a dataset ``X`` and corresponding coreset ``X_c``.
     """
 
-    def refine(self, data_reduction: DataReduction) -> None:
+    def refine(
+        self,
+        data_reduction: DataReduction,
+        kernel_mean_row_sum: ArrayLike | None = None,
+    ) -> None:
         r"""
         Compute the refined coreset, of ``m`` points in ``d`` dimensions.
 
@@ -148,6 +160,10 @@ class RefineRegular(Refine):
         :param data_reduction: :class:`~coreax.reduction.DataReduction` object with
             :math:`n \times d` original data, :math:`m` coreset point indices, coreset
             and kernel object
+        :param kernel_mean_row_sum: (Optional) Mean vector over rows for the Gram matrix,
+            a :math:`1 \times n` array. If this variable has been pre-calculated, pass
+            it here to reduce computational load. If this variable is passed,
+            `self.approximate_kernel_row_sum` is ignored.
         :return: Nothing
         """
         x = data_reduction.original_data
@@ -155,16 +171,18 @@ class RefineRegular(Refine):
 
         kernel_gram_matrix_diagonal = vmap(data_reduction.kernel.compute)(x, x)
 
-        if self.approximate_kernel_row_sum:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
-                    x, self.approximator
+        # If the user hasn't passed kernel_mean_row_sum, calculate it:
+        if kernel_mean_row_sum is None:
+            if self.approximate_kernel_row_sum:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
+                        x, self.approximator
+                    )
                 )
-            )
-        else:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
-            )
+            else:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
+                )
 
         coreset_indices = jnp.asarray(coreset_indices)
         num_points_in_coreset = len(coreset_indices)
@@ -288,7 +306,11 @@ class RefineRandom(Refine):
             approximator=approximator,
         )
 
-    def refine(self, data_reduction: DataReduction) -> None:
+    def refine(
+        self,
+        data_reduction: DataReduction,
+        kernel_mean_row_sum: ArrayLike | None = None,
+    ) -> None:
         r"""
         Refine a coreset iteratively.
 
@@ -300,6 +322,10 @@ class RefineRandom(Refine):
         :param data_reduction: :class:`~coreax.reduction.DataReduction` object with
             :math:`n \times d` original data, :math:`m` coreset point indices, coreset
             and kernel object
+        :param kernel_mean_row_sum: (Optional) Mean vector over rows for the Gram
+            matrix, a :math:`1 \times n` array. If this variable has been pre-calculated,
+             pass it here to reduce computational load. If this variable is passed,
+              `self.approximate_kernel_row_sum` is ignored.
         :return: Nothing
         """
         x = data_reduction.original_data
@@ -307,16 +333,18 @@ class RefineRandom(Refine):
 
         kernel_gram_matrix_diagonal = vmap(data_reduction.kernel.compute)(x, x)
 
-        if self.approximate_kernel_row_sum:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
-                    x, self.approximator
+        # If the user hasn't passed kernel_mean_row_sum, calculate it:
+        if kernel_mean_row_sum is None:
+            if self.approximate_kernel_row_sum:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
+                        x, self.approximator
+                    )
                 )
-            )
-        else:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
-            )
+            else:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
+                )
 
         coreset_indices = jnp.asarray(coreset_indices)
         x = jnp.asarray(x)
@@ -486,7 +514,11 @@ class RefineReverse(Refine):
     but reverses the order.
     """
 
-    def refine(self, data_reduction: DataReduction) -> None:
+    def refine(
+        self,
+        data_reduction: DataReduction,
+        kernel_mean_row_sum: ArrayLike | None = None,
+    ) -> None:
         r"""
         Refine a coreset iteratively, replacing points which yield the most improvement.
 
@@ -496,6 +528,10 @@ class RefineReverse(Refine):
         :param data_reduction: :class:`~coreax.reduction.DataReduction` object with
             :math:`n \times d` original data, :math:`m` coreset point indices, coreset
             and kernel object
+        :param kernel_mean_row_sum: (Optional) Mean vector over rows for the Gram
+            matrix, a :math:`1 \times n` array. If this variable has been
+            pre-calculated, pass it here to reduce computational load. If this variable
+            is passed, `self.approximate_kernel_row_sum` is ignored.
         :return: Nothing
         """
         x = jnp.asarray(data_reduction.original_data)
@@ -503,16 +539,18 @@ class RefineReverse(Refine):
 
         kernel_gram_matrix_diagonal = vmap(data_reduction.kernel.compute)(x, x)
 
-        if self.approximate_kernel_row_sum:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
-                    x, self.approximator
+        # If the user hasn't passed kernel_mean_row_sum, calculate it:
+        if kernel_mean_row_sum is None:
+            if self.approximate_kernel_row_sum:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.approximate_kernel_matrix_row_sum_mean(
+                        x, self.approximator
+                    )
                 )
-            )
-        else:
-            kernel_mean_row_sum = (
-                data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
-            )
+            else:
+                kernel_mean_row_sum = (
+                    data_reduction.kernel.calculate_kernel_matrix_row_sum_mean(x)
+                )
 
         num_points_in_x = len(x)
 


### PR DESCRIPTION
Refs https://github.com/gchq/coreax/issues/264

### PR Type

- Feature

### Description

This PR adds `kernel_mean_row_sum` as an optional argument to refine(), enabling caching of this variable. 

This PR mirrors the changes made on https://github.com/gchq/coreax/pull/266. This PR is created with the aim of a cleaner merge of the changes into the base branch.

### How Has This Been Tested?

No formal testing. Current refine.py unit tests need to be extended to reflect the changes.

### Does this PR introduce a breaking change?

No.

### Screenshots


### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
