### PR TITLE
Update kernel density score matching to work for both 1 and 2d arrays

### DIFF
--- a/coreax/score_matching.py
+++ b/coreax/score_matching.py
@@ -529,6 +529,7 @@ class KernelDensityMatching(ScoreMatching):
                 function at
             """
             # Check format
+            original_number_of_dimensions = x_.ndim
             x_ = jnp.atleast_2d(x_)
 
             # Get the gram matrix row means
@@ -537,7 +538,15 @@ class KernelDensityMatching(ScoreMatching):
             # Compute gradients with respect to x
             gradients = self.kernel.grad_x(x_, self.kde_data).mean(axis=1)
 
-            return gradients / gram_matrix_row_means[:, None]
+            # Compute final evaluation of the score function
+            score_result = gradients / gram_matrix_row_means[:, None]
+
+            # Ensure output format accounts for 1-dimensional inputs as-well as
+            # multi-dimensional ones
+            if original_number_of_dimensions == 1:
+                score_result = score_result[0, :]
+
+            return score_result
 
         return score_function
 

--- a/examples/pounce.py
+++ b/examples/pounce.py
@@ -96,27 +96,11 @@ def main(directory: Path = Path("../examples/data/pounce")) -> tuple[float, floa
     )
     length_scale = median_heuristic(principle_components_data[idx])
 
-    # TODO: Why does this not work?
-    # # Learn a score function via kernel density estimation
-    # sliced_score_matcher = KernelDensityMatching(
-    #     length_scale=length_scale, kde_data=principle_components_data[idx, :]
-    # )
-    # score_function = sliced_score_matcher.match()
-
-    # TODO: Temp until KernelDensityMatching is fixed
-    from jax.random import rademacher
-
-    from coreax.score_matching import SlicedScoreMatching
-
-    sliced_score_matcher = SlicedScoreMatching(
-        random_generator=rademacher,
-        use_analytic=True,
-        num_epochs=100,
-        num_random_vectors=1,
-        sigma=1.0,
-        gamma=0.95,
+    # Learn a score function via kernel density estimation
+    kernel_density_score_matcher = KernelDensityMatching(
+        length_scale=length_scale, kde_data=principle_components_data[idx, :]
     )
-    score_function = sliced_score_matcher.match(principle_components_data)
+    score_function = kernel_density_score_matcher.match()
 
     # Run kernel herding with a Stein kernel
     herding_object = KernelHerding(

--- a/examples/pounce_map_reduce.py
+++ b/examples/pounce_map_reduce.py
@@ -97,10 +97,10 @@ def main(directory: Path = Path("../examples/data/pounce")) -> tuple[float, floa
     length_scale = median_heuristic(principle_components_data[idx])
 
     # Learn a score function via kernel density estimation
-    sliced_score_matcher = KernelDensityMatching(
-        length_scale=length_scale, kde_data=principle_components_data[idx]
+    kernel_density_score_matcher = KernelDensityMatching(
+        length_scale=length_scale, kde_data=principle_components_data[idx, :]
     )
-    score_function = sliced_score_matcher.match()
+    score_function = kernel_density_score_matcher.match()
 
     # Run kernel herding with a Stein kernel in block mode to avoid GPU memory issues
     herding_object = KernelHerding(


### PR DESCRIPTION

Refs: #311

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Kernel density based score matching now works with pounce - fixing a bug where it was only valid for multi-dimensional array inputs.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

 Test A: Run examples/pounce.py
 Test B: Run all unit tests in test_score_matching.py

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
