### PR TITLE
Add coverage badge

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -19,10 +19,12 @@ bmatrix
 booktitle
 bysource
 cmap
+color
 dispname
 dollarmath
 dtype
 dtypes
+emibcn
 eprint
 figsize
 fori_loop
@@ -78,6 +80,7 @@ pytree
 pytrees
 quickstart
 rcfile
+rect
 rightarrow
 rtol
 samp

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "Coverage",
+  "message": "95%",
+  "color": "green"
+}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,19 +51,14 @@ jobs:
         }}" >> $GITHUB_OUTPUT
     - name: Create badges directory if necessary
       run: mkdir -p .github/badges
-    - name: Store copy of old badge config for comparison
+    - name: Store hash of old badge config for comparison
       id: old_file
       run: |
         if [ -f $badge_path ]; then
-          var=$( cat $badge_path )
+          echo "hash=$( sha256sum $badge_path )" >> $GITHUB_OUTPUT
         else
-          var=""
+          echo "hash=" >> $GITHUB_OUTPUT
         fi
-        {
-          echo "file<<EOF"
-          echo $var
-          echo EOF
-        } >> $GITHUB_OUTPUT
     - name: Generate badge config JSON
       run: |
         echo "coverage = ${{ steps.cov.outputs.percentage }}%"
@@ -76,20 +71,14 @@ jobs:
           echo "  \"color\": \"${{ steps.design.outputs.colour }}\""
           echo "}"
         } > $badge_path
-    - name: Store copy of new badge config for comparison
+    - name: Store hash of new badge config for comparison
       id: new_file
-      run: |
-        {
-          echo "file<<EOF"
-          echo $( cat $badge_path )
-          echo EOF
-        } >> $GITHUB_OUTPUT
+      run: echo "hash=$( sha256sum $badge_path )" >> $GITHUB_OUTPUT
     - name: Commit badge config if changed
-      if: steps.old_file.outputs.file != steps.new_file.outputs.file
+      if: steps.old_file.outputs.hash != steps.new_file.outputs.hash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         destination_branch: ${{ github.head_ref }}
-        new_badge: ${{ steps.new_file.outputs.file }}
       run: |
         export message="chore: update coverage badge"
         export sha=$( git rev-parse $destination_branch:$badge_path )

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Code Coverage Assessment
 # Run in addition to unit tests without coverage assessment in case of weirdness around
-# parallelised code
+# parallelised code. Also regenerates coverage badge.
 
 on:
   push:
@@ -12,18 +12,90 @@ on:
 
 jobs:
   coverage:
+    env:
+      badge_path: .github/badges/coverage.json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Set branch so that can commit to it later
+        ref: ${{ github.head_ref }}
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: pip
-        cache-dependency-path: requirements-test-3.11.txt
+        cache-dependency-path: requirements-dev-3.11.txt
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install test dependencies
-      run: pip install --no-dependencies -r requirements-test-3.11.txt
+      run: pip install --no-dependencies -r requirements-dev-3.11.txt
     - name: Assess coverage of unit tests
       run: pytest tests/unit --cov
+    - name: Extract total coverage percentage
+      id: cov
+      # Need to run this in own step to ensure coverage is evaluated and cast to string
+      run: echo "percentage=$( coverage report --format=total )" >> $GITHUB_OUTPUT
+    - name: Choose badge colour
+      id: design
+      env:
+        percentage: ${{ steps.cov.outputs.percentage }}
+      run: |
+        echo "colour=${{
+          env.percentage >= 90 && 'green' ||
+          env.percentage >= 70 && 'yellow' ||
+          env.percentage >= 50 && 'orange' ||
+          'red'
+        }}" >> $GITHUB_OUTPUT
+    - name: Create badges directory if necessary
+      run: mkdir -p .github/badges
+    - name: Store copy of old badge config for comparison
+      id: old_file
+      run: |
+        if [ -f $badge_path ]; then
+          var=$( cat $badge_path )
+        else
+          var=""
+        fi
+        {
+          echo "file<<EOF"
+          echo $var
+          echo EOF
+        } >> $GITHUB_OUTPUT
+    - name: Generate badge config JSON
+      run: |
+        echo "coverage = ${{ steps.cov.outputs.percentage }}%"
+        echo "colour = ${{ steps.design.outputs.colour }}"
+        {
+          echo "{"
+          echo "  \"schemaVersion\": 1,"
+          echo "  \"label\": \"Coverage\","
+          echo "  \"message\": \"${{ steps.cov.outputs.percentage }}%\","
+          echo "  \"color\": \"${{ steps.design.outputs.colour }}\""
+          echo "}"
+        } > $badge_path
+    - name: Store copy of new badge config for comparison
+      id: new_file
+      run: |
+        {
+          echo "file<<EOF"
+          echo $( cat $badge_path )
+          echo EOF
+        } >> $GITHUB_OUTPUT
+    - name: Commit badge config if changed
+      if: steps.old_file.outputs.file != steps.new_file.outputs.file
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        destination_branch: ${{ github.head_ref }}
+        new_badge: ${{ steps.new_file.outputs.file }}
+      run: |
+        export message="chore: update coverage badge"
+        export sha=$( git rev-parse $destination_branch:$badge_path )
+        export content=$( base64 -i $badge_path )
+        gh api --method PUT /repos/:owner/:repo/contents/$badge_path \
+          --field message="$message" \
+          --field content="$content" \
+          --field branch="$destination_branch" \
+          --field sha="$sha"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Badge to README to show code coverage percentage
+
 ### Fixed
 
 - Wording improvements in README

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 # Coreax
 
-[![Unit Tests and Code Coverage Assessment](https://github.com/gchq/coreax/actions/workflows/unittests.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/unittests.yml)
+[![Unit Tests](https://github.com/gchq/coreax/actions/workflows/unittests.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/unittests.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgchq%2Fcoreax%2Fmain%2F.github%2Fbadges%2Fcoverage.json)](https://github.com/gchq/coreax/actions/workflows/coverage.yml)
 [![Pre-commit Checks](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml)
 [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![Python version](https://img.shields.io/pypi/pyversions/coreax.svg)](https://pypi.org/project/coreax)


### PR DESCRIPTION
### PR Type

- CI related changes
- Documentation content changes

### Description

Create coverage badge.

Appended to coverage action. Extracts total coverage percentage, writes Endpoint JSON for shields.io then pushes commit using gh API.

Using gh API ensure bot commit is signed and does not need to sign the CLA separately. Badge is generated by shields.io using Endpoint.

### How Has This Been Tested?

 Test A: Take URL from badge in README and replace `main` with `feature/additional_badges`, then paste into https://shields.io/badges/endpoint-badge and click `Execute`.
 Test B: Edit coverage.yml to manually set coverage percentage. Badge changes colour and size accordingly.

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
