### PR TITLE
Allowing Sphinx builds to succeed despite warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
 sphinx:
   configuration: documentation/source/conf.py
   builder: "html"
-  fail_on_warning: true
+  fail_on_warning: false
 
 python:
    install:


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Build related changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Updated `.readthedocs.yaml` to allow Sphinx builds to succeed despite warnings.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

When `fail_on_warning` is `true`, the `-W` and `--keep-going` flags are passed (see [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-fail-on-warning)). The build returns a non-zero exit code when these flags are passed, but a zero exit code when they are not.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

n/a

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
