### PR TITLE
[feat]: rename weights optimisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Documentation has been rearranged
+- Renamed `coreax.weights.MMD` to `coreax.weights.MMDWeightsOptimiser` and added deprecation warning.
+- Renamed `coreax.weights.SBQ` to `coreax.weights.SBQWeightsOptimiser` and added deprecation warning.
 
 ### Removed
 
 ### Deprecated
+
+- All uses of `coreax.weights.MMD` should be replaced with `coreax.weights.MMDWeightsOptimiser`.
+- All uses of `coreax.weights.SBQ` should be replaced with `coreax.weights.SBQWeightsOptimiser`.
 
 ## [0.1.0] - 2024-02-16
 

--- a/coreax/weights.py
+++ b/coreax/weights.py
@@ -82,7 +82,7 @@ class WeightsOptimiser(ABC):
         return self.solve(x, y)
 
 
-class SBQ(WeightsOptimiser):
+class SBQWeightsOptimiser(WeightsOptimiser):
     """
     Define the Sequential Bayesian Quadrature (SBQ) optimiser class.
 
@@ -126,7 +126,7 @@ class SBQ(WeightsOptimiser):
         return jnp.linalg.solve(kernel_mm, kernel_nm)
 
 
-class MMD(WeightsOptimiser):
+class MMDWeightsOptimiser(WeightsOptimiser):
     r"""
     Define the MMD weights optimiser class.
 

--- a/coreax/weights.py
+++ b/coreax/weights.py
@@ -37,6 +37,7 @@ from abc import ABC, abstractmethod
 import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
+from typing_extensions import deprecated
 
 import coreax.kernel
 import coreax.util
@@ -182,3 +183,19 @@ class MMDWeightsOptimiser(WeightsOptimiser):
         sol = coreax.util.solve_qp(kernel_mm, kernel_nm)
 
         return sol
+
+
+@deprecated("Renamed to SBQWeightsOptimiser; will be removed in version 0.3.0")
+class SBQ(SBQWeightsOptimiser):
+    """Deprecated reference to :class:`~coreax.weights.SBQWeightsOptimiser`.
+
+    Will be removed in version 0.3.0
+    """
+
+
+@deprecated("Renamed to `MMDWeightsOptimiser`; will be removed in version 0.3.0")
+class MMD(MMDWeightsOptimiser):
+    """Deprecated reference to :class:`~coreax.weights.MMDWeightsOptimiser`.
+
+    Will be removed in version 0.3.0
+    """

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -25,7 +25,7 @@ Kernel herding with weighting
 A coreset can be weighted, a so-called **weighted coreset**, to attribute importance to
 each point and to better approximate the underlying data distribution. Optimal weights
 can be determined by implementing a :class:`~coreax.weights.WeightsOptimiser`, such as
-the :class:`~coreax.weights.MMD` weights optimiser.
+the :class:`~coreax.weights.MMDWeightsOptimiser` weights optimiser.
 
 .. literalinclude:: snippets/kernel_herding_with_weighting.py
 

--- a/documentation/source/snippets/kernel_herding_with_weighting.py
+++ b/documentation/source/snippets/kernel_herding_with_weighting.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from coreax import KernelHerding, SizeReduce, SquaredExponentialKernel
-from coreax.weights import MMD as MMDWeightsOptimiser
+from coreax.weights import MMDWeightsOptimiser
 
 # Define a kernel
 kernel = SquaredExponentialKernel(length_scale=length_scale)

--- a/examples/david_map_reduce_weighted.py
+++ b/examples/david_map_reduce_weighted.py
@@ -59,7 +59,7 @@ from coreax import (
     SteinKernel,
 )
 from coreax.kernel import PCIMQKernel, median_heuristic
-from coreax.weights import MMD as MMDWeightsOptimiser
+from coreax.weights import MMDWeightsOptimiser
 
 
 # Examples are written to be easy to read, copy and paste by users, so we ignore the

--- a/examples/herding_stein_weighted.py
+++ b/examples/herding_stein_weighted.py
@@ -51,7 +51,7 @@ from coreax import (
     SteinKernel,
 )
 from coreax.kernel import PCIMQKernel, median_heuristic
-from coreax.weights import MMD as MMDWeightsOptimiser
+from coreax.weights import MMDWeightsOptimiser
 
 
 # Examples are written to be easy to read, copy and paste by users, so we ignore the

--- a/examples/herding_stein_weighted_ssm.py
+++ b/examples/herding_stein_weighted_ssm.py
@@ -53,7 +53,7 @@ from coreax import (
     SteinKernel,
 )
 from coreax.kernel import PCIMQKernel, median_heuristic
-from coreax.weights import MMD as MMDWeightsOptimiser
+from coreax.weights import MMDWeightsOptimiser
 
 
 # Examples are written to be easy to read, copy and paste by users, so we ignore the

--- a/tests/unit/test_weights.py
+++ b/tests/unit/test_weights.py
@@ -85,7 +85,9 @@ class TestWeights(unittest.TestCase):
             ]
         )
 
-        optimiser = coreax.weights.SBQ(kernel=coreax.kernel.SquaredExponentialKernel())
+        optimiser = coreax.weights.SBQWeightsOptimiser(
+            kernel=coreax.kernel.SquaredExponentialKernel()
+        )
 
         # Solve for the weights
         output = optimiser.solve(x, y)
@@ -111,7 +113,9 @@ class TestWeights(unittest.TestCase):
             ]
         )
 
-        optimiser = coreax.weights.SBQ(kernel=coreax.kernel.SquaredExponentialKernel())
+        optimiser = coreax.weights.SBQWeightsOptimiser(
+            kernel=coreax.kernel.SquaredExponentialKernel()
+        )
 
         # Solve for the weights
         with warnings.catch_warnings(record=True) as warning_result:
@@ -200,7 +204,9 @@ class TestWeights(unittest.TestCase):
         w1 = 1 - w2
         expected_output = jnp.asarray([w1, w2])
 
-        optimiser = coreax.weights.MMD(kernel=coreax.kernel.SquaredExponentialKernel())
+        optimiser = coreax.weights.MMDWeightsOptimiser(
+            kernel=coreax.kernel.SquaredExponentialKernel()
+        )
 
         # Solve for the weights
         output = optimiser.solve(x, y)
@@ -220,7 +226,9 @@ class TestWeights(unittest.TestCase):
         y = jnp.array([[0, 0], [1, 1]])
 
         # Define weights object
-        optimiser = coreax.weights.MMD(kernel=coreax.kernel.SquaredExponentialKernel())
+        optimiser = coreax.weights.MMDWeightsOptimiser(
+            kernel=coreax.kernel.SquaredExponentialKernel()
+        )
 
         # Solve for the weights (with an invalid epsilon)
         self.assertRaises(ValueError, optimiser.solve, x, y, epsilon=-0.1)


### PR DESCRIPTION
### PR Type
Closes #448 
- Code style update (formatting, local variables)
- Refactoring (no functional changes)

### Does this PR introduce a breaking change?
- Any uses of `coreax.weights.MMD` will need to be replaced with `coreax.weights.MMDWeightsOptimiser`.
- Any uses of `coreax.weights.SBQ` will ned to be replaced with `coreax.weights.SBQWeightsOptimiser`.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
