### PR TITLE
Added missing invocation of create_custom_inv_file in conf.py, and up…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install --no-dependencies -r requirements-doc-3.11.txt
       - name: Build documentation
         run: |
-          python -m sphinx -b html -aE -n documentation/source documentation/build
+          python -m sphinx -b html -aE -n -W --keep-going documentation/source documentation/build
       - name: Check external links
         run: |
           python -m sphinx -b linkcheck documentation/source documentation/build

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -30,6 +30,7 @@ from unittest import mock
 
 import sphinx.config
 import sphobjinv
+import tqdm
 from jax.typing import ArrayLike
 from sphinx_autodoc_typehints import format_annotation as default_format_annotation
 
@@ -43,11 +44,13 @@ DOCS_FOLDER_PATH = SOURCE_FOLDER_PATH.parent
 REPO_FOLDER_PATH = DOCS_FOLDER_PATH.parent
 EXAMPLES = "examples"
 
+TQDM_CUSTOM_PATH = SOURCE_FOLDER_PATH / "tqdm.inv"
+
 sys.path.extend([str(DOCS_FOLDER_PATH), str(SOURCE_FOLDER_PATH), str(REPO_FOLDER_PATH)])
 
 
 # pylint: disable=wrong-import-position
-for module_name in ("jaxopt", "tqdm"):
+for module_name in ("jaxopt",):
     # only needed to import coreax, not actually used on import
     sys.modules[module_name] = mock.Mock()
 from ref_style import STYLE_NAME  # needed to fix citations within the docstrings
@@ -143,7 +146,7 @@ intersphinx_mapping = {  # linking to external documentation
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
-    "tqdm": ("https://tqdm.github.io/docs/", str(SOURCE_FOLDER_PATH / "tqdm.inv")),
+    "tqdm": ("https://tqdm.github.io/docs/", str(TQDM_CUSTOM_PATH)),
 }
 
 nitpick_ignore = [
@@ -298,3 +301,9 @@ def create_custom_inv_file(
     if file_name is None:
         file_name = f"{module.__name__}.inv"
     sphobjinv.writebytes(SOURCE_FOLDER_PATH / file_name, compressed_inventory_bytes)
+
+
+TQDM_CUSTOM_PATH = SOURCE_FOLDER_PATH / "tqdm.inv"
+if not TQDM_CUSTOM_PATH.exists():
+    print("Creating custom inventory file for tqdm")
+    create_custom_inv_file(tqdm, tqdm_refs)

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -303,7 +303,6 @@ def create_custom_inv_file(
     sphobjinv.writebytes(SOURCE_FOLDER_PATH / file_name, compressed_inventory_bytes)
 
 
-TQDM_CUSTOM_PATH = SOURCE_FOLDER_PATH / "tqdm.inv"
 if not TQDM_CUSTOM_PATH.exists():
     print("Creating custom inventory file for tqdm")
     create_custom_inv_file(tqdm, tqdm_refs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ doc = [
     "sphinx-toolbox",
     "sphinxcontrib-bibtex",
     "sphobjinv",
+    "tqdm",
 ]
 # All tools for a developer including those for running pylint
 dev = [

--- a/requirements-doc-3.11.txt
+++ b/requirements-doc-3.11.txt
@@ -78,6 +78,7 @@ tabulate==0.9.0
 tensorstore==0.1.53
 threadpoolctl==3.3.0
 toolz==0.12.1
+tqdm==4.66.2
 typing_extensions==4.9.0
 urllib3==2.2.1
 webencodings==0.5.1


### PR DESCRIPTION
…dated documentation tests to fail on warnings as with ReadTheDocs

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- Documentation content changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

`conf.py` was missing an actual call of the function which created the `tqdm.inv` file.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

After deleting all created files and starting again, the documentation was failing with error. Now it is not!

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

 No

### Screenshots
n/a

(Write your answer here.)

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
