### PR TITLE
style: update unittest comparison order to be (actual, expected)

### DIFF
--- a/tests/unit/test_approximation.py
+++ b/tests/unit/test_approximation.py
@@ -228,7 +228,7 @@ class TestApproximations(unittest.TestCase):
         approx_error_partial = np.sum(
             np.square(self.true_distances - approximate_kernel_mean_partial)
         )
-        self.assertTrue(approx_error_full <= approx_error_partial)
+        self.assertLessEqual(approx_error_full, approx_error_partial)
 
     def test_random_approximator_creation_invalid_types(self) -> None:
         """
@@ -371,7 +371,7 @@ class TestApproximations(unittest.TestCase):
         approx_error_partial = np.sum(
             np.square(self.true_distances - approximate_kernel_mean_partial)
         )
-        self.assertTrue(approx_error_full <= approx_error_partial)
+        self.assertLessEqual(approx_error_full, approx_error_partial)
 
     def test_annchor_approximator_creation_invalid_types(self) -> None:
         """
@@ -513,7 +513,7 @@ class TestApproximations(unittest.TestCase):
         approx_error_partial = np.sum(
             np.square(self.true_distances - approximate_kernel_mean_partial)
         )
-        self.assertTrue(approx_error_full <= approx_error_partial)
+        self.assertLessEqual(approx_error_full, approx_error_partial)
 
     def test_nystrom_approximator_creation_invalid_types(self) -> None:
         """

--- a/tests/unit/test_coresubset.py
+++ b/tests/unit/test_coresubset.py
@@ -530,8 +530,8 @@ class TestRandomSample(unittest.TestCase):
         )
 
         unique_reduction_indices = jnp.unique(random_sample.coreset_indices)
-        self.assertTrue(
-            len(unique_reduction_indices) < len(random_sample.coreset_indices)
+        self.assertLess(
+            len(unique_reduction_indices), len(random_sample.coreset_indices)
         )
 
 

--- a/tests/unit/test_score_matching.py
+++ b/tests/unit/test_score_matching.py
@@ -695,10 +695,10 @@ class TestSlicedScoreMatching(unittest.TestCase):
 
         # Jax is row based, so transpose W_
         np.testing.assert_array_almost_equal(
-            weights_.T, state.params["Dense_0"]["kernel"], decimal=3
+            state.params["Dense_0"]["kernel"], weights_.T, decimal=3
         )
         np.testing.assert_array_almost_equal(
-            bias_, state.params["Dense_0"]["bias"], decimal=3
+            state.params["Dense_0"]["bias"], bias_, decimal=3
         )
 
     # pylint: enable=too-many-locals


### PR DESCRIPTION
Refs: #177

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Refactoring (no functional changes)
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

All unit tests have been checked, and comparisons of the sort `self.assertEqual(...)` have inputs in the order actual, then expected.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

All unit test files searched through and altered where the order was found to be inconsistent. 

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
