### PR TITLE
docs: added detail back into SBQ weights docstring

### DIFF
--- a/coreax/weights.py
+++ b/coreax/weights.py
@@ -83,12 +83,30 @@ class WeightsOptimiser(ABC):
 
 
 class SBQ(WeightsOptimiser):
-    """
+    r"""
     Define the Sequential Bayesian Quadrature (SBQ) optimiser class.
 
     References for this technique can be found in :cite:`huszar2016optimally`.
-    Weighted determined by SBQ are equivalent to the unconstrained weighted maximum mean
+    Weights determined by SBQ are equivalent to the unconstrained weighted maximum mean
     discrepancy (MMD) optimum.
+
+    The Bayesian quadrature estimate of the integral
+
+    .. math::
+
+        \int f(x) p(x) dx
+
+    can be viewed as a  weighted version of kernel herding. The Bayesian quadrature
+    weights, :math:`w_{BQ}`, are given by
+
+    .. math::
+
+        w_{BQ}^{(n)} = \sum_m z_m^T K_{mn}^{-1}
+
+    for a dataset :math:`x` with :math:`n` points, and coreset :math:`y` of :math:`m`
+    points. Here, for given kernel :math:`k`, we have :math:`z = \int k(x, y)p(x) dx`
+    and :math:`K = k(y, y)` in the above expression. See equation 20 in
+    :cite:`huszar2016optimally` for further detail.
 
     :param kernel: :class:`~coreax.kernel.Kernel` object
     """


### PR DESCRIPTION
Refs: #298

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Documentation content changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Detail previously removed in the docstring of SBQ weights optimizer has been restored. See https://github.com/gchq/coreax/issues/298#issue-2052575006 for details.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

N/A

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

(Write your answer here.)

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
