### PR TITLE
Style/hard coded strings 94

### DIFF
--- a/coreax/reduction.py
+++ b/coreax/reduction.py
@@ -201,7 +201,7 @@ class Coreset(ABC):
         :return: Optimal weighting of points in :attr:`coreset` to represent the
             original data
         """
-        self.validate_fitted("solve_weights")
+        self.validate_fitted(Coreset.solve_weights.__name__)
         return self.weights_optimiser.solve(
             self.original_data.pre_coreset_array, self.coreset
         )
@@ -230,7 +230,7 @@ class Coreset(ABC):
         :return: Metric computed as a zero-dimensional array
         """
         coreax.validation.validate_is_instance(metric, "metric", coreax.metrics.Metric)
-        self.validate_fitted("compute_metric")
+        self.validate_fitted(Coreset.compute_metric.__name__)
         # block_size will be validated by metric.compute()
         return metric.compute(
             self.original_data.pre_coreset_array,
@@ -261,12 +261,12 @@ class Coreset(ABC):
 
         :return: Array of formatted data
         """
-        self.validate_fitted("format")
+        self.validate_fitted(Coreset.format.__name__)
         return self.original_data.format(self)
 
     def render(self) -> None:
         """Plot coreset interactively using :mod:`matplotlib.pyplot`."""
-        self.validate_fitted("render")
+        self.validate_fitted(Coreset.render.__name__)
         return self.original_data.render(self)
 
     def copy_fit(self, other: Coreset, deep: bool = False) -> None:
@@ -283,7 +283,7 @@ class Coreset(ABC):
         :raises TypeError: If ``other`` does not have the **exact same type**.
         """
         coreax.validation.validate_is_instance(other, "other", type(self))
-        other.validate_fitted("copy_fit from another Coreset")
+        other.validate_fitted(Coreset.copy_fit.__name__ + " from another Coreset")
         if deep:
             self.coreset = copy(other.coreset)
             self.coreset_indices = copy(other.coreset_indices)
@@ -303,7 +303,9 @@ class Coreset(ABC):
             self.coreset, Array
         ):
             raise coreax.util.NotCalculatedError(
-                f"Need to call fit before calling {caller_name}"
+                "Need to call "
+                + Coreset.fit.__name__
+                + f" before calling {caller_name}"
             )
 
 

--- a/pre_commit_hooks/require_ascii.py
+++ b/pre_commit_hooks/require_ascii.py
@@ -45,7 +45,8 @@ Based on jumanjihouse/pre-commit-hooks require-ascii hook. Original copyright:
 import itertools
 import sys
 
-MAX_ASCII_CODE = 255  # https://theasciicode.com.ar/
+# https://theasciicode.com.ar/
+MAX_ASCII_CODE = 255
 
 
 def main() -> None:


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Code style update (formatting, local variables)
- Refactoring (no functional changes)


### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Hard coded strings across the codebase have been assessed. The following comments apply, to be approved or pushed back against during review.

Actions taken:

- In pre_commit_hooks/require_ascii.py, there is a hard-coded string reading `"UTF-8"`. This is fundamental to the specific pre-commit hook so should not need changing, ever. Suggestion: Leave hard-coded string here as it is. However, there is an inline comment on line 48: `MAX_ASCII_CODE = 255  # https://theasciicode.com.ar/1` which goes against the style guide suggestion to avoid inline comments, so I have moved the comment above the relevant code.

- Inside of coreax/reduction.py, we have various calls to `self.validate_fitted(...)` where the dots are replaced by a name of the method that must have been called to continue with the code.Suggestion: To ensure consistency with method names and these hard-coded strings if one is updated but not the other during development, we could instead use ClassName.MethodName.__name__ in these calls (I've updated the code to do this to showcase this suggestion). This would error if the name of a method was changed, but the developer forgot to change the `self.validate_fitted` call, rather than specifying an error message with an old method name.

Areas not addressed with reasons:

- There are several in documentation/source/conf.py & documentation/source/ref_style.py, these all relate to options for documentation building, links, package names. On line 307, there is a hard-coded print statement: `print("Creating custom inventory file for tqdm")` which is only done if a relevant path does not exist. Suggestion: Keep all hard-coded strings in these file as there would be little benefit in refactoring, and it may even simply make the code harder to read and maintain.

- In the examples (examples/*), we have several paths that point to files that are hard-coded, for example `Path("../examples/data/david_orig.png")`. Suggestion: Do not alter these, as users who are trying out the codebase for the first time can easily see where files are coming from, and find them for manual comparison on their machines when needed. 

- In the integration tests (tests/integration/*) we have various input paths hard-coded, however these refer to the same files that are written into the files in examples/*. We also have instances where we check specific calls, for example, that the string `"Image dimensions: (215, 180)"` was printed during the David test. Suggestion: no change needed.

- In the integration tests (tests/integration/*), there are various (duplicated) hard-coded strings that read `"MMD for random sampling was unexpectedly lower than coreset MMD"`. A generic string could be placed inside of a constants module and called from there. Is this worth doing in this instance? Suggestion: discuss if it's worth having template tests strings for these occurrences. 

- In the performance tests, there are various function argument names referenced by hard-coded string, for example: 
	`"i": 0,
     "val": (coreset_indices_0, kernel_similarity_penalty_0),
     "x": x[i],
     "kernel_vectorised": kernel.compute,
     "kernel_matrix_row_sum_mean": kernel_matrix_rsm,
     "unique": True,
	`
	It seems unnecessary to have a constants module with each parameter name listed out, so the suggestion here is to take no action.

- Throughout coreax/*, there are various hard-coded strings relating to input validation. Suggestion: Take no action until input validation has been finalised. When input validation is being finalised, we make concurrent hard-coded string changes and review as part of the same PRs.

- Whenever a pytree is defined, the objects `aux_data` needs to be specified as a dict with keys being objects names and values being the objects themselves. Currently, all of these `aux_data` objects have hard-coded strings. This again relates to the question of, do we want to have the list of all method/class/function inputs written somewhere and referenced when needed? It would need careful updating whenever the code is updated, however would avoid these hard-coded strings when we define pytrees. Suggestion: discuss if the maintenance trade-off is worth having relevant method/class/function inputs written into a constants module. We would need to ensure that the function input matches exactly the corresponding string in the constants module.

- In coreax/util.py there are hard coded  strings `"Cannot guarantee recompilation of `fn`."` and `f"precision_threshold must be positive; value {precision_threshold} given."`. Suggestion: No action taken here as we have these for very specific reasons & error handling

- In coreax/weights/py, we have a temporary hard-coded string inside of `solve_approximate` (this method currently just uses the exact solve). Suggestion: No update at this point, we remove the hard-coded string when approximate solving is introduced.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

All tests run and pass locally.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
