### PR TITLE
feat: improve pre-commit fail_fast behaviour

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,18 +49,6 @@ repos:
           - text
         exclude:
           .pylintrc
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      # Prevent common mistakes of `assert mck.not_called()`,
-      # `assert mck.called_once_with(...)` and `mck.assert_called`
-      - id: python-check-mock-methods
-      # Check for the `eval()` built-in function - necessary for security
-      - id: python-no-eval
-      # Check for the deprecated `.warn()` method of Python loggers
-      - id: python-no-log-warn
-      # Enforce that type annotations are used instead of type comments
-      - id: python-use-type-annotations
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:
@@ -73,11 +61,41 @@ repos:
       # No tabs, only spaces
       - id: forbid-tabs
         exclude: documentation/make.bat|documentation/Makefile
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.3.0
+    hooks:
+      # Run a spellcheck (words pulled from cspell.config.yaml)
+      - id: cspell
+        exclude: |
+          (?x)^(
+            .gitignore|
+            .*.properties|
+            requirements(-.*)?.txt|
+            documentation/make.bat|
+            documentation/Makefile|
+            documentation/assets/Logo.svg|
+            documentation/assets/LogoMark.svg|
+            .pylintrc
+          )$
+
+  # Python specific Hooks
   - repo: https://github.com/regebro/pyroma
     rev: "4.2"
     hooks:
       # Ensure that necessary package information is provided
       - id: pyroma
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      # Prevent common mistakes of `assert mck.not_called()`,
+      # `assert mck.called_once_with(...)` and `mck.assert_called`
+      - id: python-check-mock-methods
+      # Check for the `eval()` built-in function - necessary for security
+      - id: python-no-eval
+      # Check for the deprecated `.warn()` method of Python loggers
+      - id: python-no-log-warn
+      # Enforce that type annotations are used instead of type comments
+      - id: python-use-type-annotations
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
@@ -86,24 +104,12 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-        # Don't run the slow cspell and pylint hooks unless everything else passes.
+        # Don't run the slow pylint hook unless all prior hooks have passed.
+        # Note: the behaviour of `fail_fast` diverges from that documented,
+        # https://pre-commit.com/#hooks-fail_fast. The documentation should
+        # instead read: "if true, pre-commit will stop running hooks if this
+        # *or any previous* hook fails".
         fail_fast: true
-  - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.3.0
-    hooks:
-      # Run a spellcheck (words pulled from cspell.config.yaml)
-        - id: cspell
-          exclude: |
-            (?x)^(
-              .gitignore|
-              .*.properties|
-              requirements(-.*)?.txt|
-              documentation/make.bat|
-              documentation/Makefile|
-              documentation/assets/Logo.svg|
-              documentation/assets/LogoMark.svg|
-              .pylintrc
-            )$
   - repo: local
     hooks:
       # Python static analysis tool

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-fail_fast: true
 default_install_hook_types:
   - pre-commit
   - pre-merge-commit
@@ -38,6 +37,18 @@ repos:
         args:
           - --ignore-case
           - --unique
+  - repo: local
+    hooks:
+      # Check for non-ascii characters in files
+      - id: require-ascii
+        name: Check file encoding
+        description: Ensure file is ascii-encoded
+        entry: python pre_commit_hooks/require_ascii.py
+        language: python
+        types:
+          - text
+        exclude:
+          .pylintrc
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
@@ -62,6 +73,11 @@ repos:
       # No tabs, only spaces
       - id: forbid-tabs
         exclude: documentation/make.bat|documentation/Makefile
+  - repo: https://github.com/regebro/pyroma
+    rev: "4.2"
+    hooks:
+      # Ensure that necessary package information is provided
+      - id: pyroma
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
@@ -70,11 +86,8 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/regebro/pyroma
-    rev: "4.2"
-    hooks:
-      # Ensure that necessary package information is provided
-      - id: pyroma
+        # Don't run the slow cspell and pylint hooks unless everything else passes.
+        fail_fast: true
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v8.3.0
     hooks:
@@ -93,16 +106,6 @@ repos:
             )$
   - repo: local
     hooks:
-      # Check for non-ascii characters in files
-      - id: require-ascii
-        name: Check file encoding
-        description: Ensure file is ascii-encoded
-        entry: python pre_commit_hooks/require_ascii.py
-        language: python
-        types:
-          - text
-        exclude:
-          .pylintrc
       # Python static analysis tool
       - id: pylint
         name: pylint


### PR DESCRIPTION
Closes #484

### PR Type
Improves the fail_fast behaviour in pre-commit to minimise the iteration count and time for pre-commit.

- CI related changes
- Tests


### How Has This Been Tested?
Pre-commit will only fail fast if an error has been raised before getting to cspell or pylint

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
