### PR TITLE
fix: avoid merge conflicts if branch already exists

### DIFF
--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           git checkout main
           echo "hash=$( sha256sum $config_path )" >> $GITHUB_OUTPUT
+      - name: Overwrite config on branch with version from main
+        run: |
+          git checkout ${{ env.update_branch }}
+          git checkout main ${{ env.config_path }}
       - name: Run Pre-commit autoupdate
         id: autoupdate
         run: |
@@ -71,7 +75,6 @@ jobs:
         id: commit
         if: steps.old_file.outputs.hash != steps.new_file.outputs.hash
         run: |
-          git checkout -m ${{ env.update_branch }}
           export message="chore(deps): autoupdate pre-commit hooks"
           export sha=$( git rev-parse ${{ env.update_branch }}:${{ env.config_path }} )
           export content=$( base64 -i ${{ env.config_path }} )

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -53,16 +53,12 @@ jobs:
       - name: Store hash of baseline pre-commit config for comparison
         id: old_file
         run: echo "hash=$( sha256sum $config_path )" >> $GITHUB_OUTPUT
+      - name: Overwrite config on branch with version from main
+        run: git checkout main ${{ env.config_path }}
       - name: Store hash of main pre-commit config for comparison
         id: main_file
-        run: |
-          git checkout main
-          echo "hash=$( sha256sum $config_path )" >> $GITHUB_OUTPUT
-      - name: Overwrite config on branch with version from main
-        run: |
-          git checkout ${{ env.update_branch }}
-          git checkout main ${{ env.config_path }}
-      - name: Run Pre-commit autoupdate
+        run: echo "hash=$( sha256sum $config_path )" >> $GITHUB_OUTPUT
+      - name: Run pre-commit autoupdate on main pre-commit config
         id: autoupdate
         run: |
           pre-commit autoupdate > ${{ env.update_message_path }}


### PR DESCRIPTION
closes #505

### PR Type

- Bugfix
- CI related changes

### Description

Copy the version of pre-commit config from main onto the chore branch, then run pre-commit autoupdate on the chore branch. This should avoid merge conflicts resulting from running autoupdate on main.

We want to run pre-commit autoupdate on the config from main, not whatever happens to already be on the chore branch.

### How Has This Been Tested?

 Test A: Create two branches locally. Commit the same file with different contents to each of them. Run `git checkout branch1 filename`. The file on the target branch should now be a copy of that on the other branch.

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
