### PR TITLE
Update comment on fail_fast to reflect fixed bug in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,11 +108,8 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-        # Don't run the slow pylint hook unless all prior hooks have passed.
-        # Note: the behaviour of `fail_fast` diverges from that documented,
-        # https://pre-commit.com/#hooks-fail_fast. The documentation should
-        # instead read: "if true, pre-commit will stop running hooks if this
-        # *or any previous* hook fails".
+        # Don't run the slow pylint hook if ruff has failed as there is some duplication
+        # of functionality
         fail_fast: true
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
 # All tools for a developer including those for running pylint
 dev = [
     "coreax[doc, test]",
-    "pre-commit",
+    "pre-commit>=3.7",
     "pylint",
     "pyroma",
     "ruff",


### PR DESCRIPTION
closes #513

### PR Type

- CI related changes
- Documentation content changes

### Description

Update comment on pre-commit `fail_fast` to reflect behaviour change in v3.7.0. Add this version constraint to project dependencies.

As this does not affect the main codebase, only developer experience, I have not added this to the changelog.

### How Has This Been Tested?

 Test A: GitHub runners pass

### Does this PR introduce a breaking change?

No

### Screenshots

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
