### PR TITLE
Run GitHub workflow automatically after Pre-commit auto-update

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -104,6 +104,7 @@ typehints
 undoc
 unflatten
 unsrt
+vars
 viewcode
 vmap
 writebytes

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -2,25 +2,29 @@ name: Autoupdate pre-commit config
 
 on:
   schedule:
-    - cron: "0 0 * * 6"
+    - cron: "0 0 * * 0"
 
 jobs:
   pre_commit_autoupdate:
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       config_path: .pre-commit-config.yaml
       update_message_path: /tmp/message.txt
       update_branch: chore/pre-commit-autoupdate
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
+          private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}
       - uses: actions/checkout@v4
         with:
           ref: main
       - name: Create or checkout update branch
         id: create_branch
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           export pr_number=$( gh pr view ${{ env.update_branch }} --json number --jq '.number' )
           export pr_state=$( gh pr view ${{ env.update_branch }} --json state --jq '.state' )
@@ -70,6 +74,8 @@ jobs:
       - name: Commit (with signature) pre-commit config
         id: commit
         if: steps.old_file.outputs.hash != steps.new_file.outputs.hash
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           export message="chore(deps): autoupdate pre-commit hooks"
           export sha=$( git rev-parse ${{ env.update_branch }}:${{ env.config_path }} )
@@ -81,6 +87,8 @@ jobs:
             --field sha="$sha"
       - name: Create or update pre-commit-autoupdate pull-request
         if: steps.commit.conclusion == 'success' || ( steps.main_file.outputs.hash != steps.new_file.outputs.hash )
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run : |
           export title="chore(deps): autoupdate pre-commit hooks"
           export body=$( cat ${{ env.update_message_path }} )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wording improvements in README.
 - Documentation now builds without warnings.
+- GitHub workflow runs automatically after Pre-commit autoupdate.
 
 ### Changed
 


### PR DESCRIPTION
refs: #495

### PR Type

- CI related changes

### Description

Using an app token ensures GitHub workflows run automatically on created PR.

Also move schedule to 00:00 on Monday to mean updates are less stale for working week.

Depends on Git app being set up.

### How Has This Been Tested?

 Test A: Similar set-up on a private repo.

### Does this PR introduce a breaking change?

No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
