### PR TITLE
fix: update coverage badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Coreax
 
 [![Unit Tests](https://github.com/gchq/coreax/actions/workflows/unittests.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/unittests.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Ftp832944%2F51dd332be75961a7dc903c67718028e1%2Fraw%2F413b109abaac5ba0551992791fe1c6539e38410a%2Fcoreax.json)](https://github.com/gchq/coreax/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Ftp832944%2F51dd332be75961a7dc903c67718028e1%2Fraw%2Fcoreax.json)](https://github.com/gchq/coreax/actions/workflows/coverage.yml)
 [![Pre-commit Checks](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml)
 [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![Python version](https://img.shields.io/pypi/pyversions/coreax.svg)](https://pypi.org/project/coreax)


### PR DESCRIPTION
### PR Type
Fixes the coverage badge URL. It now points to the latest commit.

- Bugfix


### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

(Write your answer here.)

### How Has This Been Tested?
 Test A: Manually checked the URL generates the expected badge

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
