### PR TITLE
fix: stop pre-commit if ruff linter fails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,11 +103,11 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.4
     hooks:
+      # Run the formatter.
+      - id: ruff-format
       # Run the linter.
       - id: ruff
         args: [ --fix ]
-      # Run the formatter.
-      - id: ruff-format
         # Don't run the slow pylint hook if ruff has failed as there is some duplication
         # of functionality
         fail_fast: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,14 +103,14 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.4
     hooks:
-      # Run the formatter.
-      - id: ruff-format
       # Run the linter.
       - id: ruff
         args: [ --fix ]
-        # Don't run the slow pylint hook if ruff has failed as there is some duplication
-        # of functionality
+        # Abort if ruff linter fails as there is some duplication of functionality with
+        # the slow pylint hook
         fail_fast: true
+      # Run the formatter.
+      - id: ruff-format
   - repo: local
     hooks:
       # Python static analysis tool


### PR DESCRIPTION
refs: #513

### PR Type

- CI related changes

### Description

Pre-commit was incorrectly terminating if ruff formatter fails; it should have been ruff linter.

### How Has This Been Tested?


### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
