### PR TITLE
feat: add `Coresubset` abstract base class

### DIFF
--- a/.cspell/custom_misc.txt
+++ b/.cspell/custom_misc.txt
@@ -7,9 +7,11 @@ coreset
 coresets
 coresubset
 coresubsets
+cubature
 diag
 docstrings
 elementwise
+forall
 GCHQ
 kbar
 kdtree
@@ -23,4 +25,5 @@ PRNG
 refs
 RKHS
 sigmas
+TLDR
 WMMd

--- a/coreax/coresubset.py
+++ b/coreax/coresubset.py
@@ -44,7 +44,7 @@ import coreax.util
 import coreax.weights
 
 
-class KernelHerding(coreax.reduction.Coreset):
+class KernelHerding(coreax.reduction.Coresubset):
     r"""
     Apply kernel herding to a dataset.
 
@@ -102,6 +102,13 @@ class KernelHerding(coreax.reduction.Coreset):
         self.unique = unique
         self.approximator = approximator
         self.random_key = random_key
+
+        self.kernel_matrix_row_sum_mean: ArrayLike | None = None
+        r"""
+        Mean vector over rows for the Gram matrix, a :math:`1 \times n` array. If
+        :meth:`fit_to_size` calculates this, it will be saved here automatically to save
+        recalculating it in :meth:`refine`.
+        """
 
         # Initialise parent
         super().__init__(
@@ -298,7 +305,7 @@ class KernelHerding(coreax.reduction.Coreset):
         return current_coreset_indices, current_kernel_similarity_penalty
 
 
-class RandomSample(coreax.reduction.Coreset):
+class RandomSample(coreax.reduction.Coresubset):
     r"""
     Reduce a dataset by uniformly randomly sampling a fixed number of points.
 
@@ -334,7 +341,7 @@ class RandomSample(coreax.reduction.Coreset):
         self.random_key = random_key
         self.unique = unique
 
-        # Initialise Coreset parent
+        # Initialise Coresubset parent
         super().__init__(
             weights_optimiser=weights_optimiser,
             kernel=kernel,
@@ -358,7 +365,6 @@ class RandomSample(coreax.reduction.Coreset):
         children = (
             self.random_key,
             self.kernel,
-            self.kernel_matrix_row_sum_mean,
             self.coreset_indices,
             self.coreset,
         )

--- a/coreax/refine.py
+++ b/coreax/refine.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, random, tree_util, vmap
@@ -48,10 +47,8 @@ from jax.typing import ArrayLike
 
 import coreax.approximation
 import coreax.kernel
+import coreax.reduction
 import coreax.util
-
-if TYPE_CHECKING:
-    import coreax.reduction
 
 
 class Refine(ABC):
@@ -107,7 +104,7 @@ class Refine(ABC):
         """
         # validate_fitted checks original_data
         coreset.validate_fitted("refine")
-        if coreset.coreset_indices is None:
+        if not isinstance(coreset, coreax.reduction.Coresubset):
             raise TypeError("Cannot refine when not finding a coresubset")
 
     def tree_flatten(self) -> tuple[tuple, dict]:

--- a/documentation/source/references.bib
+++ b/documentation/source/references.bib
@@ -51,3 +51,17 @@
       archivePrefix={arXiv},
       primaryClass={stat.ML}
 }
+
+@article{litterer2012recombination,
+   title={High order recombination and an application to cubature on Wiener space},
+   volume={22},
+   ISSN={1050-5164},
+   url={http://dx.doi.org/10.1214/11-AAP786},
+   DOI={10.1214/11-aap786},
+   number={4},
+   journal={The Annals of Applied Probability},
+   publisher={Institute of Mathematical Statistics},
+   author={Litterer, C. and Lyons, T.},
+   year={2012},
+   month=aug
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+"""Helpers that are used across the test suite."""
+
+import coreax.reduction
+
+
+class CoresetMock(coreax.reduction.Coreset):
+    """Test version of :class:`Coreset` with all methods implemented."""
+
+    def fit_to_size(self, coreset_size: int) -> None:
+        raise NotImplementedError
+
+
+class CoresubsetMock(coreax.reduction.Coresubset):
+    """Test version of :class:`Coresubset` with all methods implemented."""
+
+    def fit_to_size(self, coreset_size: int) -> None:
+        raise NotImplementedError

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -28,18 +28,14 @@ import jax.numpy as jnp
 from jax import random
 
 import coreax.approximation
+import coreax.coresubset
 import coreax.data
 import coreax.kernel
 import coreax.reduction
 import coreax.refine
 import coreax.util
 
-
-class CoresetMock(coreax.reduction.Coreset):
-    """Test version of :class:`Coreset` with all methods implemented."""
-
-    def fit_to_size(self, coreset_size: int) -> None:
-        raise NotImplementedError
+from ..helpers import CoresetMock, CoresubsetMock
 
 
 class TestRefine(unittest.TestCase):
@@ -52,7 +48,7 @@ class TestRefine(unittest.TestCase):
 
     def test_validate_coreset_ok(self) -> None:
         """Check validation passes with populated coresubset."""
-        coreset = CoresetMock()
+        coreset = CoresubsetMock()
         coreset.original_data = coreax.data.ArrayData.load(1)
         coreset.coreset = jnp.array(1)
         coreset.coreset_indices = jnp.array(0)
@@ -64,7 +60,7 @@ class TestRefine(unittest.TestCase):
 
     def test_validate_coreset_no_fit(self) -> None:
         """Check validation fails when coreset has not been calculated."""
-        coreset = CoresetMock()
+        coreset = CoresubsetMock()
         coreset.original_data = coreax.data.ArrayData.load(1)
         # Disable pylint warning for protected-access as we are testing a single part of
         # the over-arching algorithm
@@ -104,7 +100,7 @@ class TestRefineRegular(unittest.TestCase):
         best_indices = {0, 1}
         coreset_indices = jnp.array(list(best_indices))
 
-        coreset_obj = CoresetMock(
+        coreset_obj = CoresubsetMock(
             weights_optimiser=None, kernel=coreax.kernel.SquaredExponentialKernel()
         )
         coreset_obj.coreset_indices = coreset_indices
@@ -139,7 +135,7 @@ class TestRefineRegular(unittest.TestCase):
         for test_indices in index_pairs:
             coreset_indices = jnp.array(list(test_indices))
 
-            coreset_obj = CoresetMock(
+            coreset_obj = CoresubsetMock(
                 weights_optimiser=None,
                 kernel=coreax.kernel.SquaredExponentialKernel(),
             )
@@ -177,7 +173,7 @@ class TestRefineRegular(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -204,7 +200,7 @@ class TestRefineRegular(unittest.TestCase):
         best_indices = {0, 1}
         coreset_indices = jnp.array(list(best_indices))
 
-        coreset_obj = CoresetMock(
+        coreset_obj = CoresubsetMock(
             weights_optimiser=None, kernel=coreax.kernel.SquaredExponentialKernel()
         )
         coreset_obj.coreset_indices = coreset_indices
@@ -236,7 +232,7 @@ class TestRefineRegular(unittest.TestCase):
         approximator = coreax.approximation.RandomApproximator(
             self.random_key, kernel=kernel, num_train_points=2, num_kernel_points=2
         )
-        coreset_obj = CoresetMock(
+        coreset_obj = CoresubsetMock(
             weights_optimiser=None, kernel=coreax.kernel.SquaredExponentialKernel()
         )
         coreset_obj.coreset_indices = coreset_indices
@@ -272,7 +268,7 @@ class TestRefineRegular(unittest.TestCase):
         original_array = jnp.asarray([[0, 0], [1, 1], [0, 0], [1, 1]])
         best_indices = {0, 1}
         coreset_indices = jnp.array(list(best_indices))
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=None)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=None)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -314,7 +310,7 @@ class TestRefineRandom(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
 
-        coreset_obj = CoresetMock(
+        coreset_obj = CoresubsetMock(
             weights_optimiser=None, kernel=coreax.kernel.SquaredExponentialKernel()
         )
         coreset_obj.coreset_indices = coreset_indices
@@ -349,7 +345,7 @@ class TestRefineRandom(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -392,7 +388,7 @@ class TestRefineRandom(unittest.TestCase):
         original_array = jnp.asarray([[0, 0], [1, 1], [0, 0], [1, 1]])
         best_indices = {0, 1}
         coreset_indices = jnp.array(list(best_indices))
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=None)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=None)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -417,7 +413,7 @@ class TestRefineRandom(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -442,7 +438,7 @@ class TestRefineRandom(unittest.TestCase):
         original_array = jnp.asarray([])
         coreset_indices = jnp.array([])
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = jnp.asarray([])
@@ -468,7 +464,7 @@ class TestRefineRandom(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -494,7 +490,7 @@ class TestRefineRandom(unittest.TestCase):
         test_indices = [2, 2]
         coreset_indices = jnp.array(test_indices)
         kernel = coreax.kernel.SquaredExponentialKernel()
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=kernel)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=kernel)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]
@@ -538,7 +534,7 @@ class TestRefineReverse(unittest.TestCase):
         for test_indices in index_pairs:
             coreset_indices = jnp.array(list(test_indices))
 
-            coreset_obj = CoresetMock(
+            coreset_obj = CoresubsetMock(
                 weights_optimiser=None,
                 kernel=coreax.kernel.SquaredExponentialKernel(),
             )
@@ -576,7 +572,7 @@ class TestRefineReverse(unittest.TestCase):
         for test_indices in index_pairs:
             coreset_indices = jnp.array(list(test_indices))
 
-            coreset_obj = CoresetMock(
+            coreset_obj = CoresubsetMock(
                 weights_optimiser=None,
                 kernel=coreax.kernel.SquaredExponentialKernel(),
             )
@@ -615,7 +611,7 @@ class TestRefineReverse(unittest.TestCase):
         original_array = jnp.asarray([[0, 0], [1, 1], [0, 0], [1, 1]])
         best_indices = {0, 1}
         coreset_indices = jnp.array(list(best_indices))
-        coreset_obj = CoresetMock(weights_optimiser=None, kernel=None)
+        coreset_obj = CoresubsetMock(weights_optimiser=None, kernel=None)
         coreset_obj.coreset_indices = coreset_indices
         coreset_obj.original_data = coreax.data.ArrayData.load(original_array)
         coreset_obj.coreset = original_array[coreset_indices, :]


### PR DESCRIPTION
### PR Type
Closes #518 
- Feature
- Refactoring (no functional changes)
- Documentation content changes
- Tests

### Description
- Updates the `Coreset` docstring
- Moves `kernel_matrix_row_sum_mean` into `KernelHerding` (this attribute is not required for general `Coreset` algorithms)
- Adds a `Coresubset` abstract base class
- Updates existing `Coresubset` algorithms to inherit from the newly added `Coresubset` class
- Adjust previous `Coresubset` checks to test on the instance type of a given `Coresubset` (not the value of `Coresubset.corset_indices`)
- Converts `TestCoreset` to use pytest, allowing parameterization of the test on both `Coreset` and `Coresubset`
- Moves mocks used in multiple tests, `CoresetMock` and `CoresubsetMock`, into a new `tests/helpers.py`


### How Has This Been Tested?
Changes have been made to the test suite where necessary.

### Does this PR introduce a breaking change?
The implicit determination mechanisms (if `Coreset.coreset_indices is None` then is `Coresubset`) no longer work. Instead, determination of a `Coreset` as a `Coresubset` should be performed with `isinstance(coreset, Coresubset)`.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
