### PR TITLE
feat: utilise pytest for `test_approximation`

### DIFF
--- a/tests/unit/test_approximation.py
+++ b/tests/unit/test_approximation.py
@@ -131,23 +131,19 @@ class TestApproximations:
             true_distances,
         ) = problem
         # Define the approximator - full dataset used to fit the approximation
-        if not issubclass(approximator, coreax.approximation.NystromApproximator):
+        if issubclass(approximator, coreax.approximation.NystromApproximator):
+            full_kwargs = {"num_kernel_points": data.shape[0]}
+            partial_kwargs = {"num_kernel_points": num_kernel_points}
+        else:
             full_kwargs = {
                 "num_kernel_points": data.shape[0],
                 "num_train_points": data.shape[0],
             }
-        else:
-            full_kwargs = {"num_kernel_points": data.shape[0]}
-        approximator_full = approximator(random_key, kernel, **full_kwargs)
-
-        # Define the approximator - full dataset used to fit the approximation
-        if not issubclass(approximator, coreax.approximation.NystromApproximator):
             partial_kwargs = {
                 "num_kernel_points": num_kernel_points,
                 "num_train_points": num_train_points,
             }
-        else:
-            partial_kwargs = {"num_kernel_points": num_kernel_points}
+        approximator_full = approximator(random_key, kernel, **full_kwargs)
         approximator_partial = approximator(random_key, kernel, **partial_kwargs)
 
         # Approximate the kernel row mean using the full training set (so the
@@ -188,14 +184,14 @@ class TestApproximations:
             num_train_points,
             true_distances,
         ) = problem
-        if not issubclass(approximator, coreax.approximation.NystromApproximator):
+        if issubclass(approximator, coreax.approximation.NystromApproximator):
             kwargs = {
-                "num_kernel_points": num_kernel_points * num_kernel_points_multiplier,
-                "num_train_points": num_train_points,
+                "num_kernel_points": num_kernel_points * num_kernel_points_multiplier
             }
         else:
             kwargs = {
-                "num_kernel_points": num_kernel_points * num_kernel_points_multiplier
+                "num_kernel_points": num_kernel_points * num_kernel_points_multiplier,
+                "num_train_points": num_train_points,
             }
         test_approximator = approximator(random_key, kernel, **kwargs)
 
@@ -291,13 +287,13 @@ class TestApproximations:
             num_train_points,
             _,
         ) = problem
-        if not issubclass(approximator, coreax.approximation.NystromApproximator):
+        if issubclass(approximator, coreax.approximation.NystromApproximator):
+            kwargs = {"num_kernel_points": num_kernel_points}
+        else:
             kwargs = {
                 "num_kernel_points": num_kernel_points,
                 "num_train_points": num_train_points,
             }
-        else:
-            kwargs = {"num_kernel_points": num_kernel_points}
         approximator = approximator(random_key, coreax.util.InvalidKernel(0), **kwargs)
         with pytest.raises(
             AttributeError,


### PR DESCRIPTION
### PR Type
Closes #532

- Feature
- Refactoring (no functional changes)
- Tests

### Description
Refactors the tests in `test_approximation.py` to utilise pytest fixtures and parameterization.

### How Has This Been Tested?
The new tests pass.

### Does this PR introduce a breaking change?
Removes the `test_kernel_mean_approximator_creation` as this is implicitly tested by all the other tests.
Uses the same "almost_equal" tolerance for all approximators (pulls random down to the tolerance used in ANN and Nystrom).

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
