### PR TITLE
Remove forbid-binary hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,16 +49,11 @@ repos:
         description: Ensure file is ascii-encoded
         entry: python pre_commit_hooks/require_ascii.py
         language: python
-        types:
-          - text
         exclude:
-          .pylintrc
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 3.0.0
-    hooks:
-      # Check for binary files
-      - id: forbid-binary
-        exclude: ^examples/.+/.+.(gif|png)$
+          (?x)^(
+            .pylintrc|
+            examples/.+/.+.(gif|png)
+          )$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
closes #540

### PR Type

- CI related changes

### Description

The forbid-binary Pre-commit hook appears to be no longer maintained. Remove it as it's redundant with require-ascii hook. Apply require-ascii hook to all files.

### How Has This Been Tested?

 Test A: Run Pre-commit on all files

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
