### PR TITLE
feat: utilise pytest for `test_kernel`

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -60,6 +60,7 @@ mimsave
 modindex
 myst
 nabla
+ndarray
 ndim
 nonzero
 numpy

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -848,23 +848,9 @@ class SteinKernel(Kernel):
         output_scale: float = 1.0,
     ):
         """Define the Stein kernel, i.e. the application of the Stein operator."""
-        # Check that the base_kernel provided has the relevant JAX pytree methods to
-        # allow functionality within this kernel
-        if not hasattr(base_kernel, "tree_flatten"):
-            raise AttributeError(
-                "base_kernel must have the method tree_flatten implemented"
-            )
-
-        if not hasattr(base_kernel, "tree_unflatten"):
-            raise AttributeError(
-                "base_kernel must have the method tree_unflatten implemented"
-            )
-
         self.base_kernel = base_kernel
         self.score_function = score_function
         self.output_scale = output_scale
-
-        # Initialise parent
         super().__init__(output_scale=output_scale)
 
     def tree_flatten(self) -> tuple[tuple, dict]:

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -62,11 +62,12 @@ class _PairwiseProblemFactory(Protocol, Generic[_Kernel_contra]):
     ) -> tuple[ArrayLike, ArrayLike, Array | np.ndarray]: ...
 
 
-class _Problem(NamedTuple, Generic[_Kernel]):
+# Once we support only python 3.11+ this should be generic on _Kernel
+class _Problem(NamedTuple):
     x: ArrayLike
     y: ArrayLike
     expected_output: ArrayLike
-    kernel: _Kernel
+    kernel: Kernel
 
 
 class BaseKernelTest(ABC, Generic[_Kernel]):
@@ -81,9 +82,7 @@ class BaseKernelTest(ABC, Generic[_Kernel]):
         """
 
     @abstractmethod
-    def problem(
-        self, request, kernel_factory: _KernelFactory[_Kernel]
-    ) -> _Problem[_Kernel]:
+    def problem(self, request, kernel_factory: _KernelFactory[_Kernel]) -> _Problem:
         """Abstract pytest fixture which returns a problem for ``Kernel.compute``."""
 
     @pytest.fixture
@@ -121,7 +120,7 @@ class BaseKernelTest(ABC, Generic[_Kernel]):
 
         return pairwise_problem
 
-    def test_compute(self, problem: _Problem[_Kernel]):
+    def test_compute(self, problem: _Problem):
         """Test ``compute`` method of ``coreax.kernel.Kernel``."""
         x, y, expected_output, kernel = problem
         output = kernel.compute(x, y)
@@ -316,7 +315,7 @@ class TestSquaredExponentialKernel(
         self,
         request,
         kernel_factory: _KernelFactory[SquaredExponentialKernel],
-    ) -> _Problem[SquaredExponentialKernel]:
+    ) -> _Problem:
         r"""
         Test problems for the SquaredExponential kernel.
 
@@ -463,7 +462,7 @@ class TestLaplacianKernel(
         self,
         request,
         kernel_factory: _KernelFactory[LaplacianKernel],
-    ) -> _Problem[LaplacianKernel]:
+    ) -> _Problem:
         r"""
         Test problems for the Laplacian kernel.
 
@@ -592,7 +591,7 @@ class TestPCIMQKernel(
         self,
         request,
         kernel_factory: _KernelFactory[PCIMQKernel],
-    ) -> _Problem[PCIMQKernel]:
+    ) -> _Problem:
         r"""
         Test problems for the PCIMQ kernel.
 
@@ -718,7 +717,7 @@ class TestSteinKernel(BaseKernelTest[SteinKernel]):
         self,
         request,
         kernel_factory: _KernelFactory[SteinKernel],
-    ) -> _Problem[SteinKernel]:
+    ) -> _Problem:
         """Test problem for the Stein kernel."""
         length_scale = 1 / np.sqrt(2)
         kernel = kernel_factory(length_scale, 1.0)

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -19,1993 +19,666 @@ The tests within this file verify that the implementations of kernels used throu
 the codebase produce the expected results on simple examples.
 """
 
-import unittest
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
+
+import contextlib
+from abc import ABC, abstractmethod
+from typing import Generic, Literal, NamedTuple, Protocol, TypeVar
 
 import numpy as np
-from jax import Array, tree_util
+import pytest
+from jax import Array
 from jax import numpy as jnp
 from jax.typing import ArrayLike
 from scipy.stats import norm as scipy_norm
+from typing_extensions import override
 
-import coreax.approximation
-import coreax.kernel
-import coreax.util
-
-
-class KernelNoDivergenceMethod:
-    """
-    Example kernel with no method to compute divergence of inputs.
-
-    This kernel is used to verify handling of invalid inputs to Stein kernels.
-    """
-
-    def __init__(self, a: float):
-        """Initialise the KernelNoDivergenceMethod class."""
-        self.a = a
-
-    def tree_flatten(self) -> tuple[tuple, dict]:
-        """
-        Flatten a pytree.
-
-        Define arrays & dynamic values (children) and auxiliary data (static values).
-        A method to flatten the pytree needs to be specified to enable JIT decoration
-        of methods inside this class.
-
-        :return: Tuple containing two elements. The first is a tuple holding the arrays
-            and dynamic values that are present in the class. The second is a dictionary
-            holding the static auxiliary data for the class, with keys being the names
-            of class attributes, and values being the values of the corresponding class
-            attributes.
-        """
-        children = ()
-        aux_data = {"a": self.a}
-        return children, aux_data
-
-    @classmethod
-    def tree_unflatten(cls, aux_data, children):
-        """
-        Reconstruct a pytree from the tree definition and the leaves.
-
-        Arrays & dynamic values (children) and auxiliary data (static values) are
-        reconstructed. A method to reconstruct the pytree needs to be specified to
-        enable JIT decoration of methods inside this class.
-        """
-        return cls(*children, **aux_data)
-
-    def compute_elementwise(self, x: ArrayLike, y: ArrayLike) -> Array:
-        r"""
-        Evaluate kernel on two inputs ``x`` and ``y``.
-
-        We assume ``x`` and ``y`` are two vectors of the same dimension.
-
-        :param x: Vector :math:`\mathbf{x} \in \mathbb{R}^d`
-        :param y: Vector :math:`\mathbf{y} \in \mathbb{R}^d`
-        :return: Kernel evaluated at (``x``, ``y``)
-        """
-        return self.a * (x + y)
-
-
-# Register the example kernel
-tree_util.register_pytree_node(
-    KernelNoDivergenceMethod,
-    KernelNoDivergenceMethod.tree_flatten,
-    KernelNoDivergenceMethod.tree_unflatten,
+from coreax.kernel import (
+    Kernel,
+    LaplacianKernel,
+    PCIMQKernel,
+    SquaredExponentialKernel,
+    SteinKernel,
 )
 
+_Kernel = TypeVar("_Kernel", bound=Kernel)
+_Kernel_co = TypeVar("_Kernel_co", bound=Kernel, covariant=True)
+_Kernel_contra = TypeVar("_Kernel_contra", bound=Kernel, contravariant=True)
 
-class KernelNoTreeFlatten:
-    """
-    Example kernel with no method to flatten a pytree.
 
-    This kernel is used to verify handling of invalid inputs to Stein kernels.
-    """
+class _KernelFactory(Protocol, Generic[_Kernel_co]):
+    def __call__(self, length_scale: float, output_scale: float) -> _Kernel_co: ...
 
-    def __init__(self, a: float):
-        """Initialise the KernelNoTreeFlatten class."""
-        self.a = a
 
-    @classmethod
-    def tree_unflatten(cls, aux_data, children):
+class _PairwiseProblemFactory(Protocol, Generic[_Kernel_contra]):
+    def __call__(
+        self,
+        kernel: _Kernel_contra,
+        i: int = 0,
+        j: int = 0,
+        max_size: int | None = None,
+        *,
+        square: bool = True,
+    ) -> tuple[ArrayLike, ArrayLike, Array | np.ndarray]: ...
+
+
+class _Problem(NamedTuple, Generic[_Kernel]):
+    x: ArrayLike
+    y: ArrayLike
+    expected_output: ArrayLike
+    kernel: _Kernel
+
+
+class BaseKernelTest(ABC, Generic[_Kernel]):
+    """Test the ``compute`` methods of a ``coreax.kernel.Kernel``."""
+
+    @abstractmethod
+    def kernel_factory(self) -> _KernelFactory[_Kernel]:
         """
-        Reconstruct a pytree from the tree definition and the leaves.
+        Abstract pytest fixture which returns a kernel factory.
 
-        Arrays & dynamic values (children) and auxiliary data (static values) are
-        reconstructed. A method to reconstruct the pytree needs to be specified to
-        enable JIT decoration of methods inside this class.
+        Factory expects a ``length_scale`` and an ``output_scale`` as inputs.
         """
-        return cls(*children, **aux_data)
 
-    def compute_elementwise(self, x: ArrayLike, y: ArrayLike) -> Array:
-        r"""
-        Evaluate kernel on two inputs ``x`` and ``y``.
+    @abstractmethod
+    def problem(
+        self, request, kernel_factory: _KernelFactory[_Kernel]
+    ) -> _Problem[_Kernel]:
+        """Abstract pytest fixture which returns a problem for ``Kernel.compute``."""
 
-        We assume ``x`` and ``y`` are two vectors of the same dimension.
-
-        :param x: Vector :math:`\mathbf{x} \in \mathbb{R}^d`
-        :param y: Vector :math:`\mathbf{y} \in \mathbb{R}^d`
-        :return: Kernel evaluated at (``x``, ``y``)
+    @pytest.fixture
+    def pairwise_problem_factory(self) -> _PairwiseProblemFactory[_Kernel]:
         """
-        return self.a * (x + y)
+        Return a factory for a ``pairwise_problem``.
 
-
-class KernelNoTreeUnflatten:
-    """
-    Example kernel with no method to unflatten a pytree.
-
-    This kernel is used to verify handling of invalid inputs to Stein kernels.
-    """
-
-    def __init__(self, a: float):
-        """Initialise the KernelNoTreeUnflatten class."""
-        self.a = a
-
-    def tree_flatten(self) -> tuple[tuple, dict]:
+        Used here for tests of ``pairwise_compute`` and for tests of
+        ``{update, calculate}_kernel_matrix_row_{sum, mean}`` in ``KernelRowSumTest``.
         """
-        Flatten a pytree.
 
-        Define arrays & dynamic values (children) and auxiliary data (static values).
-        A method to flatten the pytree needs to be specified to enable JIT decoration
-        of methods inside this class.
+        def pairwise_problem(
+            kernel: _Kernel,
+            i: int = 0,
+            j: int = 0,
+            max_size: int | None = None,
+            *,
+            square: bool = True,
+        ) -> tuple[ArrayLike, ArrayLike, Array | np.ndarray]:
+            x = np.array([[0.0], [1.0], [2.0], [3.0], [4.0]])
+            if square:
+                y = x
+            else:
+                y = np.array([[10.0], [3.0], [0.0]])
+            max_size_x = x.shape[0] if max_size is None else max_size
+            max_size_y = y.shape[0] if max_size is None else max_size
+            expected_output = np.zeros([x.shape[0], y.shape[0]])
+            if max_size == 0:
+                return x, y, expected_output
 
-        :return: Tuple containing two elements. The first is a tuple holding the arrays
-            and dynamic values that are present in the class. The second is a dictionary
-            holding the static auxiliary data for the class, with keys being the names
-            of class attributes, and values being the values of the corresponding class
-            attributes.
-        """
-        # The score function is assumed to not change here - but it might if the kernel
-        # changes - but this does not work when kernel is specified in children
-        children = ()
-        aux_data = {"a": self.a}
-        return children, aux_data
+            for x_idx, x_ in enumerate(x[i : i + max_size_x]):
+                for y_idx, y_ in enumerate(y[j : j + max_size_y]):
+                    expected_output[x_idx, y_idx] = kernel.compute(x_, y_)[0, 0]
+            return x, y, expected_output
 
-    def compute_elementwise(self, x: ArrayLike, y: ArrayLike) -> Array:
-        r"""
-        Evaluate kernel on two inputs ``x`` and ``y``.
+        return pairwise_problem
 
-        We assume ``x`` and ``y`` are two vectors of the same dimension.
-
-        :param x: Vector :math:`\mathbf{x} \in \mathbb{R}^d`
-        :param y: Vector :math:`\mathbf{y} \in \mathbb{R}^d`
-        :return: Kernel evaluated at (``x``, ``y``)
-        """
-        return self.a * (x + y)
-
-
-class TestKernelABC(unittest.TestCase):
-    """
-    Tests related to the Kernel abstract base class in ``kernel.py``.
-    """
-
-    def setUp(self):
-        """
-        Generate data for shared use across unit tests.
-        """
-        self.default_length_scale = 1 / np.sqrt(2)
-        self.default_x = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0]).reshape(-1, 1)
-        self.default_zero_kernel_row_sum = jnp.zeros(len(self.default_x))
-
-        # Define the simplest, real kernel object for testing purposes
-        self.default_kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=self.default_length_scale
-        )
-
-    def test_approximator_valid(self) -> None:
-        """
-        Test usage of approximation object within the Kernel class.
-        """
-        # Disable pylint warning for abstract-class-instantiated as we are patching
-        # these whilst testing creation of the parent class
-        # pylint: disable=abstract-class-instantiated
-        # Patch the abstract methods of the Kernel ABC, so it can be created
-        p = patch.multiple(coreax.kernel.Kernel, __abstractmethods__=set())
-        p.start()
-
-        # Create the kernel and some example data
-        kernel = coreax.kernel.Kernel()
-        x = jnp.zeros(3)
-
-        # Define a mocked approximator
-        approximator = MagicMock(spec=coreax.approximation.RandomApproximator)
-        approximator_approximate_method = MagicMock()
-        approximator.approximate = approximator_approximate_method
-        # pylint: enable=abstract-class-instantiated
-
-        # Call the approximation method and check that approximation object is called as
-        # expected
-        kernel.approximate_kernel_matrix_row_sum_mean(x=x, approximator=approximator)
-        approximator_approximate_method.assert_called_once_with(x)
-
-    def test_update_kernel_matrix_row_sum_zero_max_size(self) -> None:
-        """
-        Test how the method update_kernel_matrix_row_sum handles a zero max_size.
-        """
-        # Compute the kernel matrix row sum - a max size of 0 should mean nothing gets
-        # updated. This is expected behaviour, as max sizes of zero would get caught and
-        # addressed in the wrapper that calls this inside of the kernel class. However,
-        # this unusual choice should raise a warning to the user.
-        with self.assertWarnsRegex(UserWarning, "max_size is not positive"):
-            output = self.default_kernel.update_kernel_matrix_row_sum(
-                self.default_x,
-                self.default_zero_kernel_row_sum,
-                0,
-                0,
-                self.default_kernel.compute,
-                max_size=0,
-            )
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, self.default_zero_kernel_row_sum)
-
-    def test_update_kernel_matrix_row_sum_negative_max_size(self) -> None:
-        """
-        Test how the method update_kernel_matrix_row_sum handles a negative max_size.
-        """
-        # Define parameters for test
-        max_size = 3
-
-        # Define expected output for pairwise distances - in this case we are looking
-        # from the start index (0) to start index + max_size in both axis (rows
-        # and columns) and then adding the pairwise distances up to this point. Any
-        # pairs of points beyond this subset of indices should not be computed. However,
-        # note that when we pass max_size to the method, it's negative. Python
-        # convention therefore states 'compute from start index up to abs(max_size)
-        # elements from the end of the array'.
-        expected_output = np.zeros([5, 5])
-        for x_1_idx, x_1 in enumerate(self.default_x[0 : (5 - max_size)]):
-            for x_2_idx, x_2 in enumerate(self.default_x[0 : (5 - max_size)]):
-                expected_output[x_1_idx, x_2_idx] = self.default_kernel.compute(
-                    x_1, x_2
-                )[0, 0]
-        expected_output = expected_output.sum(axis=1)
-
-        # Compute the kernel matrix row sum - a negative max size should fill up to
-        # max_size elements from the end of the array. This is expected behaviour, as
-        # max sizes of zero would get caught and addressed in the wrapper that calls
-        # this inside of the kernel class. However, this unusual choice should raise a
-        # warning to the user.
-        with self.assertWarnsRegex(UserWarning, "max_size is not positive"):
-            output = self.default_kernel.update_kernel_matrix_row_sum(
-                self.default_x,
-                self.default_zero_kernel_row_sum,
-                0,
-                0,
-                self.default_kernel.compute,
-                max_size=-max_size,
-            )
-
-        # Check output matches expected
+    def test_compute(self, problem: _Problem[_Kernel]):
+        """Test ``compute`` method of ``coreax.kernel.Kernel``."""
+        x, y, expected_output, kernel = problem
+        output = kernel.compute(x, y)
         np.testing.assert_array_almost_equal(output, expected_output)
 
-    def test_update_kernel_matrix_row_sum_float_max_size(self) -> None:
-        """
-        Test how the method update_kernel_matrix_row_sum handles a float max_size.
-        """
-        # Compute the kernel matrix row sum - a float max size should raise an error
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.update_kernel_matrix_row_sum(
-                self.default_x,
-                self.default_zero_kernel_row_sum,
-                0,
-                0,
-                self.default_kernel.compute,
-                max_size=1.0,
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "max_size must be an integer",
-        )
-
-    def test_update_kernel_matrix_row_sum_float_index(self) -> None:
-        """
-        Test how the method update_kernel_matrix_row_sum handles a float array index.
-        """
-        # Compute the kernel matrix row sum with the class - a float index should raise
-        # an error
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.update_kernel_matrix_row_sum(
-                self.default_x,
-                self.default_zero_kernel_row_sum,
-                0.0,
-                0,
-                self.default_kernel.compute,
-                max_size=2,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "index i must be an integer",
-        )
-
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.update_kernel_matrix_row_sum(
-                self.default_x,
-                self.default_zero_kernel_row_sum,
-                0,
-                0.0,
-                self.default_kernel.compute,
-                max_size=2,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "index j must be an integer",
-        )
-
-    def test_update_kernel_matrix_row_sum_i_not_equal_j(self) -> None:
-        """
-        Test how the method update_kernel_matrix_row_sum when input indices differ.
-        """
-        # Define parameters for data
-        max_size = 3
-
-        # Define expected output for pairwise distances - in this case we are looking
-        # from the start index (0) to start index + max_size (0 + 3) in both axis (rows
-        # and columns) and then adding the pairwise distances up to this point. Any
-        # pairs of points beyond this subset of indices should not be computed
-        kernel_evaluations = np.zeros([5, 5])
-        for x_1_idx, x_1 in enumerate(self.default_x[0:max_size]):
-            for x_2_idx, x_2 in enumerate(self.default_x[1 : 1 + max_size]):
-                kernel_evaluations[x_1_idx, 1 + x_2_idx] = self.default_kernel.compute(
-                    x_1, x_2
-                )[0, 0]
-
-        # The expected output should just be the sum of the sums over each axis, as
-        # we've only filled in the relevant bits in the above loop (note x_2 starts at
-        # index 1 not 0, and j is set to 1 in the method call below)
-        expected_output = kernel_evaluations.sum(axis=0) + kernel_evaluations.sum(
-            axis=1
-        )
-
-        # Compute the kernel matrix row sum with the class
-        output = self.default_kernel.update_kernel_matrix_row_sum(
-            self.default_x,
-            self.default_zero_kernel_row_sum,
-            0,
-            1,
-            self.default_kernel.compute,
-            max_size=max_size,
-        )
-
-        # Check output matches expected
+    def test_pairwise_compute(
+        self,
+        pairwise_problem_factory: _PairwiseProblemFactory[_Kernel],
+        kernel_factory: _KernelFactory[_Kernel],
+    ):
+        """Test (pairwise) ``compute`` method of ``coreax.kernel.Kernel``."""
+        kernel = kernel_factory(1 / np.sqrt(2.0), 1.0)
+        x, y, expected_output = pairwise_problem_factory(kernel, square=False)
+        output = kernel.compute(x, y)
         np.testing.assert_array_almost_equal(output, expected_output)
 
-    def test_calculate_kernel_matrix_row_sum_zero_max_size(self) -> None:
+
+class KernelRowSumTest(Generic[_Kernel]):
+    """Test the ``kernel_matrix_row_sum`` methods of a ``coreax.kernel.Kernel``."""
+
+    @pytest.mark.parametrize(
+        "max_size, i, j",
+        [(0, 0, 1), (-3, 0, 0), (3.0, 0, 0), (3, 0.0, 0), (2, 0, 0.0)],
+        ids=[
+            "zero_max_size",
+            "negative_max_size",
+            "float_max_size",
+            "float_i",
+            "float_j",
+        ],
+    )
+    def test_updated_kernel_matrix_row_sum(
+        self,
+        pairwise_problem_factory: _PairwiseProblemFactory[_Kernel],
+        kernel_factory: _KernelFactory[_Kernel],
+        max_size: int,
+        i: int,
+        j: int,
+    ):
         """
-        Test kernel matrix row sum method when given a zero value of max_size.
+        Test ``updated_kernel_matrix_row_sum`` method of ``coreax.kernel.Kernel``.
         """
-        # Compute the kernel matrix row sum with a max size of 0, which would make
-        # computations impossible, so we expect an error to be raised
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum(
-                x=self.default_x, max_size=0
+        warn_context = error_context = contextlib.nullcontext()
+        if max_size <= 0:
+            warn_context = pytest.warns(UserWarning, match="max_size is not positive")
+        elif any(isinstance(x, float) for x in [max_size, i, j]):
+            error_context = pytest.raises(ValueError, match="must be an integer")
+
+        kernel = kernel_factory(1 / np.sqrt(2), 1.0)
+        x, _, expected_output = pairwise_problem_factory(
+            kernel, i=int(i), j=int(j), max_size=int(max_size)
+        )
+        sum_expected_output = expected_output.sum(axis=-1)
+        if int(i) != int(j):
+            sum_expected_output += expected_output.sum(axis=0)
+
+        kernel_row_sum = jnp.zeros(max(jnp.shape(x)))
+        with warn_context, error_context:
+            output = kernel.update_kernel_matrix_row_sum(
+                x, kernel_row_sum, i, j, kernel.compute, max_size=max_size
+            )
+        if isinstance(error_context, contextlib.nullcontext):
+            np.testing.assert_array_almost_equal(output, sum_expected_output)
+
+    @pytest.mark.parametrize(
+        "max_size",
+        [0, -3, 3.2],
+        ids=["zero_max_size", "negative_max_size", "float_max_size"],
+    )
+    def test_calculate_kernel_matrix_row_sum_and_mean(
+        self,
+        pairwise_problem_factory: _PairwiseProblemFactory[_Kernel],
+        kernel_factory: _KernelFactory[_Kernel],
+        max_size: int,
+    ):
+        """
+        Test ``calculate_kernel_matrix_row_{x}`` methods of ``coreax.kernel.Kernel``.
+        """
+        context = contextlib.nullcontext()
+        if max_size <= 0:
+            context = pytest.raises(
+                ValueError, match="max_size must be a positive integer"
+            )
+        elif isinstance(max_size, float):
+            context = pytest.raises(
+                TypeError, match="object cannot be interpreted as an integer"
             )
 
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "max_size must be a positive integer",
-        )
-
-    def test_calculate_kernel_matrix_row_sum_negative_max_size(self) -> None:
-        """
-        Test kernel matrix row sum method when given a negative value of max_size.
-        """
-        # Compute the kernel matrix row sum with a negative max size. To avoid nonsense
-        # answers, this should raise an error
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum(
-                x=self.default_x, max_size=-2
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "max_size must be a positive integer",
-        )
-
-    def test_calculate_kernel_matrix_row_sum_float_max_size(self) -> None:
-        """
-        Test kernel matrix row sum method when given a float value of max_size.
-        """
-        # Compute the kernel matrix row sum with a negative max size. To avoid nonsense
-        # answers, this should raise an error
-        with self.assertRaises(TypeError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum(
-                x=self.default_x, max_size=2.0
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "'float' object cannot be interpreted as an integer",
-        )
-
-    def test_calculate_kernel_matrix_row_sum_mean_zero_max_size(self) -> None:
-        """
-        Test kernel matrix row sum mean method when given a zero value of max_size.
-        """
-        # Compute the kernel matrix row sum mean with a max size of 0, which would make
-        # computations impossible, so we expect an error to be raised
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum_mean(
-                x=self.default_x, max_size=0
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "max_size must be a positive integer",
-        )
-
-    def test_calculate_kernel_matrix_row_sum_mean_negative_max_size(self) -> None:
-        """
-        Test kernel matrix row sum mean method when given a negative value of max_size.
-        """
-        # Compute the kernel matrix row sum mean with a float max size. To avoid
-        # nonsense answers, this should raise an error
-        with self.assertRaises(ValueError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum_mean(
-                x=self.default_x, max_size=-2
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "max_size must be a positive integer",
-        )
-
-    def test_calculate_kernel_matrix_row_sum_mean_float_max_size(self) -> None:
-        """
-        Test kernel matrix row sum mean method when given a float value of max_size.
-        """
-        # Compute the kernel matrix row sum mean with a float max size. To avoid
-        # nonsense answers, this should raise an error
-        with self.assertRaises(TypeError) as error_raised:
-            self.default_kernel.calculate_kernel_matrix_row_sum_mean(
-                x=self.default_x, max_size=2.0
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "'float' object cannot be interpreted as an integer",
-        )
+        kernel = kernel_factory(1 / np.sqrt(2), 1.0)
+        x, _, expected_output = pairwise_problem_factory(kernel)
+        sum_expected_output = expected_output.sum(axis=-1)
+        mean_expected_output = sum_expected_output / jnp.shape(x)[0]
+        with context:
+            sum_output = kernel.calculate_kernel_matrix_row_sum(x, max_size)
+        with context:
+            mean_output = kernel.calculate_kernel_matrix_row_sum_mean(x, max_size)
+        if isinstance(context, contextlib.nullcontext):
+            np.testing.assert_array_almost_equal(sum_output, sum_expected_output)
+            np.testing.assert_array_almost_equal(mean_output, mean_expected_output)
 
 
-class TestSquaredExponentialKernel(unittest.TestCase):
-    """
-    Tests related to the SquaredExponentialKernel defined in ``kernel.py``.
-    """
+class KernelGradientTest(ABC, Generic[_Kernel]):
+    """Test the gradient and divergence methods of a ``coreax.kernel.Kernel``."""
 
-    def test_squared_exponential_kernel_unexpected_length_scale(self) -> None:
+    @pytest.fixture
+    def gradient_problem(self):
+        """Return a problem for testing kernel gradients and divergence."""
+        num_points = 10
+        dimension = 2
+        random_data_generation_key = 1_989
+        generator = np.random.default_rng(random_data_generation_key)
+        x = generator.random((num_points, dimension))
+        y = generator.random((num_points, dimension))
+        return x, y
+
+    @pytest.mark.parametrize("mode", ["grad_x", "grad_y", "divergence_x_grad_y"])
+    @pytest.mark.parametrize("elementwise", [False, True])
+    @pytest.mark.parametrize(
+        "length_scale, output_scale",
+        [(np.sqrt(np.float32(np.pi) / 2.0), 1.0), (1.0, np.e)],
+    )
+    def test_gradients(
+        self,
+        gradient_problem: tuple[Array, Array],
+        kernel_factory: _KernelFactory[_Kernel],
+        length_scale: float,
+        output_scale: float,
+        mode: Literal["grad_x", "grad_y", "divergence_x_grad_y"],
+        elementwise: bool,
+    ):
+        """Test computation of the kernel gradients."""
+        x, y = gradient_problem
+        kernel = kernel_factory(length_scale, output_scale)
+        test_mode = mode
+        reference_mode = "expected_" + mode
+        if elementwise:
+            test_mode += "_elementwise"
+            x, y = x[:, 0], y[:, 0]
+        expected_output = getattr(self, reference_mode)(x, y, kernel)
+        if elementwise:
+            expected_output = expected_output.squeeze()
+        output = getattr(kernel, test_mode)(x, y)
+        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
+
+    @abstractmethod
+    def expected_grad_x(
+        self, x: ArrayLike, y: ArrayLike, kernel: _Kernel
+    ) -> Array | np.ndarray:
+        """Compute expected gradient of the kernel w.r.t ``x``."""
+
+    @abstractmethod
+    def expected_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: _Kernel
+    ) -> Array | np.ndarray:
+        """Compute expected gradient of the kernel w.r.t ``y``."""
+
+    @abstractmethod
+    def expected_divergence_x_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: _Kernel
+    ) -> Array | np.ndarray:
+        """Compute expected divergence of the kernel w.r.t ``x`` gradient ``y``."""
+
+
+class TestSquaredExponentialKernel(
+    BaseKernelTest[SquaredExponentialKernel],
+    KernelRowSumTest[SquaredExponentialKernel],
+    KernelGradientTest[SquaredExponentialKernel],
+):
+    """Test ``coreax.kernel.SquaredExponentialKernel``."""
+
+    @pytest.fixture
+    def kernel_factory(self) -> _KernelFactory[SquaredExponentialKernel]:
+        def kernel(length_scale, output_scale):
+            return SquaredExponentialKernel(length_scale, output_scale)
+
+        return kernel
+
+    @override
+    @pytest.fixture(
+        params=[
+            "floats",
+            "vectors",
+            "arrays",
+            "normalized",
+            "negative_length_scale",
+            "large_negative_length_scale",
+            "near_zero_length_scale",
+            "negative_output_scale",
+        ]
+    )
+    def problem(  # noqa: C901
+        self,
+        request,
+        kernel_factory: _KernelFactory[SquaredExponentialKernel],
+    ) -> _Problem[SquaredExponentialKernel]:
         r"""
-        Test SquaredExponentialKernel computations with unexpected length_scale inputs.
+        Test problems for the SquaredExponential kernel.
 
-        The SquaredExponential kernel is defined as
+        The kernel is defined as
         :math:`k(x,y) = \exp (-||x-y||^2/(2 * \text{length_scale}^2))`.
-        Whilst a negative choice of length_scale would be unusual, the kernel can still
-        be evaluated using it. Since the length_scale gets squared in the computation,
-        the negative values should give the same results as the positive values. Very
-        small values of length_scale will result in the exponential of a very large
-        number, giving results approximately equal to 0. Very large values of
-        length_scale will result in an exponential of values very near zero, yielding
-        1.0.
 
-        For the two input floats
-        .. math::
+        We consider the following cases:
+        1. length scale is :math:`\sqrt{\pi} / 2`:
+        - `floats`: where x and y are floats
+        - `vectors`: where x and y are vectors of the same size
+        - `arrays`: where x and y are arrays of the same shape
 
-            x = 0.5
+        2. length scale is :math:`\exp(1)` and output scale is
+        :math:`\frac{1}{\sqrt{2*\pi} * \exp(1)}`:
+        - `normalized`: where x and y are vectors of the same size (this is the
+        special case where the squared exponential kernel is the Gaussian kernel)
 
-            y = 2.0
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            ||x - y||^2 &= (0.5 - 2.0)^2
-                        &= 2.25
-
-        If we take the length_scale to be 1.0, we get:
-            k(x, y) &= \exp(- 2.25 / 2.0)
-                    &= 0.324652467
+        3. length scale or output scale is degenerate:
+        - `negative_length_scale`: should give same result as positive equivalent
+        - `large_negative_length_scale`: should approximately equal one
+        - `near_zero_length_scale`: should approximately equal zero
+        - `negative_output_scale`: should negate the positive equivalent.
         """
-        # Create the kernel with a positive length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of -1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=1.0)
-        self.assertEqual(kernel.compute(0.5, 2.0), 0.324652467)
-
-        # Create the kernel with a negative length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=-1.0)
-        self.assertEqual(kernel.compute(0.5, 2.0), 0.324652467)
-
-        # Create the kernel with a large negative length_scale, which should just
-        # yield an exponential to the power of almost zero and hence a result of 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=-10000.0)
-        self.assertEqual(kernel.compute(0.5, 2.0), 1.0)
-
-        # Create the kernel with a small negative length_scale, which should just
-        # yield an exponential to the power of a very large negative number and hence
-        # a result of 0.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=-0.0000001)
-        self.assertEqual(kernel.compute(0.5, 2.0), 0.0)
-
-    def test_squared_exponential_kernel_unexpected_output_scale(self) -> None:
-        """
-        Test SquaredExponentialKernel computations with unexpected output_scale inputs.
-
-        This example uses the same length_scale demonstrated in
-        test_squared_exponential_kernel_unexpected_length_scale. Although a negative
-        output_scale would be unusual, there should be no issue evaluating the kernel
-        with this.
-        """
-        kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=1.0, output_scale=1.0
-        )
-        self.assertEqual(kernel.compute(0.5, 2.0), 0.324652467)
-
-        kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=1.0, output_scale=-1.0
-        )
-        self.assertEqual(kernel.compute(0.5, 2.0), -0.324652467)
-
-    def test_squared_exponential_kernel_compute_two_floats(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel distance computations.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-
-        For the two input floats
-        .. math::
-
-            x = 0.5
-
-            y = 2.0
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            ||x - y||^2 &= (0.5 - 2.0)^2
-                        &= 2.25
-
-        If we take the length_scale to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x, y) &= \exp(- 2.25 / \pi)
-                    &= 0.48860678
-
-        If the length_scale is instead taken to be :math:`\sqrt{\pi}`, we get:
-            k(x, y) &= \exp(- 2.25 / (2.0\pi))
-                    &= 0.6990041
-        """
-        # Define data and length_scale
+        kernel = kernel_factory(np.sqrt(np.float32(np.pi) / 2.0), 1.0)
+        mode = request.param
         x = 0.5
         y = 2.0
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
+        if mode == "floats":
+            expected_distances = 0.48860678
+        elif mode == "vectors":
+            x = 1.0 * np.arange(4)
+            y = x + 1.0
+            expected_distances = 0.279923327
+        elif mode == "arrays":
+            x = np.array(([0, 1, 2, 3], [5, 6, 7, 8]))
+            y = np.array(([1, 2, 3, 4], [5, 6, 7, 8]))
+            expected_distances = np.array(
+                [[0.279923327, 1.4996075e-14], [1.4211038e-09, 1.0]]
+            )
+        elif mode == "normalized":
+            kernel.length_scale = np.e
+            kernel.output_scale = 1 / (np.sqrt(2 * np.pi) * kernel.length_scale)
+            num_points = 10
+            x = np.arange(num_points)
+            y = x + 1.0
 
-        # Define the expected distance - it should just be a number in this case since
-        # we have floats as inputs, so treat these single data-points in space
-        expected_distance = 0.48860678
+            # Compute expected output using standard implementation of the Gaussian PDF
+            expected_distances = np.zeros((num_points, num_points))
+            for x_idx, x_ in enumerate(x):
+                for y_idx, y_ in enumerate(y):
+                    expected_distances[x_idx, y_idx] = scipy_norm(
+                        y_, kernel.length_scale
+                    ).pdf(x_)
+            x, y = x.reshape(-1, 1), y.reshape(-1, 1)
+        elif mode == "negative_length_scale":
+            kernel.length_scale = -1
+            expected_distances = 0.324652467
+        elif mode == "large_negative_length_scale":
+            kernel.length_scale = -10000.0
+            expected_distances = 1.0
+        elif mode == "near_zero_length_scale":
+            kernel.length_scale = -0.0000001
+            expected_distances = 0.0
+        elif mode == "negative_output_scale":
+            kernel.length_scale = 1
+            kernel.output_scale = -1
+            expected_distances = -0.324652467
+        else:
+            raise ValueError("Invalid problem mode")
 
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
+        return _Problem(x, y, expected_distances, kernel)
 
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-        # Alter the length_scale, and check the JIT decorator catches the update
-        kernel.length_scale = np.sqrt(np.float32(np.pi))
-
-        # Set expected output with this new length_scale
-        expected_distance = 0.6990041
-
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y, with the new, altered length_scale
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-    def test_squared_exponential_kernel_compute_two_vectors(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel distance computations.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-
-        For the two input vectors
-
-        .. math::
-
-            x = [0, 1, 2, 3]
-
-            y = [1, 2, 3, 4]
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            ||x - y||^2 &= (0 - 1)^2 + (1 - 2)^2 + (2 - 3)^2 + (3 - 4)^2
-                        &= 4
-
-        If we take the ``length_scale`` to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x, y) &= \exp(- 4 / \pi)
-                    &= 0.279923327
-        """
-        # Define data and length_scale
-        x = 1.0 * np.arange(4)
-        y = x + 1.0
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
-
-        # Define the expected distance - it should just be a number in this case since
-        # we have 1-dimensional arrays, so treat these as single data-points in space
-        expected_distance = 0.279923327
-
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-    def test_squared_exponential_kernel_compute_two_arrays(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel distance computations on arrays.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-
-        For the two input vectors
-        .. math::
-
-            x = [ [0, 1, 2, 3], [5, 6, 7, 8] ]
-
-            y = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
-
-        For our choices of ``x`` and ``y``, we have distances of:
-
-        .. math::
-
-            ||x - y||^2 = [4, 0]
-
-        If we take the ``length_scale`` to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x[0], y[0]) &= \exp(- 4 / \pi)
-                          &= 0.279923327
-            k(x[0], y[1]) &= \exp(- 100 / \pi)
-                          &= 1.4996075 \times 10^{-14}
-            k(x[1], y[0]) &= \exp(- 64 / \pi)
-                          &= 1.4211038 \times 10^{-9}
-            k(x[1], y[1]) &= \exp(- 0 / \pi)
-                          &= 1.0
-
-        """
-        # Define data and length_scale
-        x = np.array(([0, 1, 2, 3], [5, 6, 7, 8]))
-        y = np.array(([1, 2, 3, 4], [5, 6, 7, 8]))
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
-
-        # Define the expected Gram matrix
-        expected_distances = np.array(
-            [[0.279923327, 1.4996075e-14], [1.4211038e-09, 1.0]]
-        )
-
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Evaluate the kernel - which computes the Gram matrix between ``x`` and ``y``
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        np.testing.assert_array_almost_equal(output, expected_distances, decimal=5)
-
-    def test_squared_exponential_kernel_gradients_wrt_x(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel gradient computations.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-        The gradient of this with respect to ``x`` is:
-
-        .. math:
-            - \frac{(x - y)}{\text{length_scale}^{3}\sqrt(2\pi)}e^{-\frac{|x-y|^2}{
-                2 \text{length_scale}^2}
-            }
-        """
-        # Define some data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to x
-        true_gradients = np.zeros((num_points, num_points, dimension))
+    def expected_grad_x(self, x: ArrayLike, y: ArrayLike, kernel: Kernel) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        expected_gradients = np.zeros((num_points, num_points, dimension))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    -(x[x_idx, :] - y[y_idx, :])
-                    / length_scale**2
-                    * np.exp(
-                        -(np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2)
-                        / (2 * length_scale**2)
-                    )
-                )
-
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Evaluate the gradient
-        output = kernel.grad_x(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_squared_exponential_kernel_grad_x_elementwise(self) -> None:
-        """
-        Test SquaredExponentialKernel element-wise gradient computations w.r.t. ``x``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (
-            -(x - y)
-            / length_scale**2
-            * np.exp(-(np.abs(x - y) ** 2) / (2 * length_scale**2))
-        )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        output = kernel.grad_x_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_scaled_squared_exponential_kernel_gradients_wrt_x(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel gradient computations; with scaling.
-
-        The scaled SquaredExponential kernel is defined as
-        :math:`k(x,y) = s\exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-        The gradient of this with respect to ``x`` is:
-
-        .. math:
-            - s\frac{(x - y)}{\text{length_scale}^{3}\sqrt(2\pi)}e^{-\frac{|x-y|^2}{
-                2 \text{length_scale}^2}
-            }
-        """
-        # Define some data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to x
-        true_gradients = np.zeros((num_points, num_points, dimension))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    -1.0
-                    * output_scale
+                expected_gradients[x_idx, y_idx] = (
+                    -kernel.output_scale
                     * (x[x_idx, :] - y[y_idx, :])
-                    / length_scale**2
+                    / kernel.length_scale**2
                     * np.exp(
                         -(np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2)
-                        / (2 * length_scale**2)
+                        / (2 * kernel.length_scale**2)
                     )
                 )
+        return expected_gradients
 
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
+    def expected_grad_y(self, x: ArrayLike, y: ArrayLike, kernel: Kernel) -> np.ndarray:
+        return -self.expected_grad_x(x, y, kernel)
 
-        # Evaluate the gradient
-        output = kernel.grad_x(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_squared_exponential_kernel_gradients_wrt_y(self) -> None:
-        r"""
-        Test the class SquaredExponentialKernel gradient computations.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-        The gradient of this with respect to ``y`` is:
-
-        .. math:
-            \frac{(x - y)}{\text{length_scale}^{3}\sqrt(2\pi)}e^{-\frac{|x-y|^2}{
-                2 \text{length_scale}^2}
-            }
-        """
-        # Define some data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to y
-        true_gradients = np.zeros((num_points, num_points, dimension))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    (x[x_idx, :] - y[y_idx, :])
-                    / length_scale**2
-                    * np.exp(
-                        -(np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2)
-                        / (2 * length_scale**2)
-                    )
-                )
-
-        # Create the kernel
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Evaluate the gradient
-        output = kernel.grad_y(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_squared_exponential_kernel_grad_y_elementwise(self) -> None:
-        """
-        Test SquaredExponentialKernel element-wise gradient computations w.r.t. ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (
-            (x - y)
-            / length_scale**2
-            * np.exp(-(np.abs(x - y) ** 2) / (2 * length_scale**2))
-        )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        output = kernel.grad_y_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_pairwise_kernel_evaluation(self) -> None:
-        r"""
-        Test the definition of pairwise kernel evaluation functions.
-
-        Pairwise distances mean, given two input arrays, we should return a matrix
-        where the values correspond to the distance, as defined by the kernel, between
-        each point in the first array and each point in the second array.
-
-        The SquaredExponential kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||^2/2 * \text{length_scale}^2)`.
-        If we have two input arrays:
-
-        .. math:
-            x = [0.0, 1.0, 2.0, 3.0, 4.0]
-            y = [10.0, 3.0, 0.0]
-
-        then we expect an output matrix with 5 rows and 3 columns. Entry [0, 0] in that
-        matrix is the kernel distance between points 0.0 and 10.0, entry [0, 1] is the
-        kernel distance between 0.0 and 3.0 and so on.
-        """
-        # Define parameters for data
-        length_scale = 1 / np.sqrt(2)
-        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0]).reshape(-1, 1)
-        y = np.array([10.0, 3.0, 0.0]).reshape(-1, 1)
-
-        # Define the kernel object
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define expected output for pairwise distances
-        expected_output = np.zeros([5, 3])
-        for x_idx, x_ in enumerate(x):
-            for y_idx, y_ in enumerate(y):
-                expected_output[x_idx, y_idx] = kernel.compute(x_, y_)[0, 0]
-
-        # Compute the pairwise distances between the data using the kernel
-        output = kernel.compute(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output)
-
-    def test_update_kernel_matrix_row_sum(self) -> None:
-        """
-        Test updates to the kernel matrix row sum.
-
-        In this test, we consider a subset of points (determined by the parameter
-        max_size) and then compute the sum of pairwise distances between them. Any
-        points outside this subset should not alter the existing kernel row sum values.
-        """
-        # Define parameters for data
-        length_scale = 1 / np.sqrt(2)
-        x = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0]).reshape(-1, 1)
-        max_size = 3
-
-        # Pre-specify an empty kernel matrix row sum to update as we go
-        kernel_row_sum = jnp.zeros(len(x))
-
-        # Define the kernel object
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define expected output for pairwise distances - in this case we are looking
-        # from the start index (0) to start index + max_size (0 + 3) in both axis (rows
-        # and columns) and then adding the pairwise distances up to this point. Any
-        # pairs of points beyond this subset of indices should not be computed
-        expected_output = np.zeros([5, 5])
-        for x_1_idx, x_1 in enumerate(x[0:max_size]):
-            for x_2_idx, x_2 in enumerate(x[0:max_size]):
-                expected_output[x_1_idx, x_2_idx] = kernel.compute(x_1, x_2)[0, 0]
-        expected_output = expected_output.sum(axis=1)
-
-        # Compute the kernel matrix row sum with the class
-        output = kernel.update_kernel_matrix_row_sum(
-            x, kernel_row_sum, 0, 0, kernel.compute, max_size=max_size
-        )
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output)
-
-    def test_calculate_kernel_matrix_row_sum(self) -> None:
-        """
-        Test computation of the kernel matrix row sum.
-
-        We compute the distance between all pairs of points, and then sum these
-        distances, giving a single value for each data-point.
-        """
-        # Define parameters for data
-        length_scale = 1 / np.sqrt(2)
-        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
-        x = x.reshape(-1, 1)
-
-        # Define the kernel object
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define expected output for pairwise distances
-        expected_output = np.zeros([5, 5])
-        for x_1_idx, x_1 in enumerate(x):
-            for x_2_idx, x_2 in enumerate(x):
-                expected_output[x_1_idx, x_2_idx] = kernel.compute(x_1, x_2)[0, 0]
-        expected_output = expected_output.sum(axis=1)
-
-        # Compute the kernel matrix row sum with the class
-        output = kernel.calculate_kernel_matrix_row_sum(x)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output)
-
-    def test_calculate_kernel_matrix_row_sum_mean(self) -> None:
-        """
-        Test computation of the mean of the kernel matrix row sum.
-
-        We compute the distance between all pairs of points, and then take the mean of
-        these distances, giving a single value for each data-point.
-        """
-        # Define parameters for data
-        length_scale = 1 / np.sqrt(2)
-        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
-        x = x.reshape(-1, 1)
-
-        # Define the kernel object
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define expected output for pairwise distances, then take the mean of them
-        expected_output = np.zeros([5, 5])
-        for x_1_idx, x_1 in enumerate(x):
-            for x_2_idx, x_2 in enumerate(x):
-                expected_output[x_1_idx, x_2_idx] = kernel.compute(x_1, x_2)[0, 0]
-        expected_output = expected_output.mean(axis=1)
-
-        # Compute the kernel matrix row sum mean with the class
-        output = kernel.calculate_kernel_matrix_row_sum_mean(x)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output)
-
-    def test_compute_normalised(self) -> None:
-        """
-        Test computation of normalised SquaredExponential kernel.
-
-        A normalised SquaredExponential kernel is also known as a Gaussian kernel. We
-        generate data and compare to a standard implementation of the Gaussian PDF.
-        """
-        # Setup some data
-        length_scale = np.e
-        num_points = 10
-        x = np.arange(num_points)
-        y = x + 1.0
-
-        # Compute expected output using standard implementation of the Gaussian PDF
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx, x_ in enumerate(x):
-            for y_idx, y_ in enumerate(y):
-                expected_output[x_idx, y_idx] = scipy_norm(y_, length_scale).pdf(x_)
-
-        # Compute the normalised PDF output using the kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=length_scale,
-            output_scale=1 / (np.sqrt(2 * np.pi) * length_scale),
-        )
-        output = kernel.compute(x.reshape(-1, 1), y.reshape(-1, 1))
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_squared_exponential_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
+    def expected_divergence_x_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: Kernel
+    ) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        expected_divergence = np.zeros((num_points, num_points))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
                 dot_product = np.dot(
                     x[x_idx, :] - y[y_idx, :], x[x_idx, :] - y[y_idx, :]
                 )
-                expected_output[x_idx, y_idx] = (
-                    2 * np.exp(-dot_product) * (dimension - 2 * dot_product)
+                kernel_scaled = kernel.output_scale * np.exp(
+                    -dot_product / (2.0 * kernel.length_scale**2)
                 )
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_squared_exponential_div_x_grad_y_elementwise(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of Jacobian w.r.t. ``y`` element-wise.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = 2 * np.exp(-((x - y) ** 2)) * (1 - 2 * (x - y) ** 2)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y_elementwise(x, y)
-
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_scaled_squared_exponential_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``; scaled.
-        """
-        # Setup data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                dot_product = np.dot(
-                    x[x_idx, :] - y[y_idx, :], x[x_idx, :] - y[y_idx, :]
-                )
-                kernel_scaled = output_scale * np.exp(
-                    -dot_product / (2.0 * length_scale**2)
-                )
-                expected_output[x_idx, y_idx] = (
+                expected_divergence[x_idx, y_idx] = (
                     kernel_scaled
-                    / length_scale**2
-                    * (dimension - dot_product / length_scale**2)
+                    / kernel.length_scale**2
+                    * (dimension - dot_product / kernel.length_scale**2)
                 )
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SquaredExponentialKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
-        output = kernel.divergence_x_grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
+        return expected_divergence
 
 
-class TestLaplacianKernel(unittest.TestCase):
-    """
-    Tests related to the LaplacianKernel defined in ``kernel.py``.
-    """
+class TestLaplacianKernel(
+    BaseKernelTest[LaplacianKernel],
+    KernelRowSumTest[LaplacianKernel],
+    KernelGradientTest[LaplacianKernel],
+):
+    """Test ``coreax.kernel.LaplacianKernel``."""
 
-    def test_laplacian_kernel_unexpected_length_scale(self) -> None:
+    @pytest.fixture
+    def kernel_factory(self):
+        def kernel(length_scale, output_scale):
+            return LaplacianKernel(length_scale, output_scale)
+
+        return kernel
+
+    @override
+    @pytest.fixture(
+        params=[
+            "floats",
+            "vectors",
+            "arrays",
+            "negative_length_scale",
+            "large_negative_length_scale",
+            "near_zero_length_scale",
+            "negative_output_scale",
+        ]
+    )
+    def problem(
+        self,
+        request,
+        kernel_factory: _KernelFactory[LaplacianKernel],
+    ) -> _Problem[LaplacianKernel]:
         r"""
-        Test LaplacianKernel computations with unexpected length_scale inputs.
+        Test problems for the Laplacian kernel.
 
-        The Laplacian kernel is defined as
+        The kernel is defined as
         :math:`k(x,y) = \exp (-||x-y||_1/(2 * \text{length_scale}^2))`.
-        Whilst a negative choice of length_scale would be unusual, the kernel can still
-        be evaluated using it. Since the length_scale gets squared in the computation,
-        the negative values should give the same results as the positive values. Very
-        small values of length_scale will result in the exponential of a very large
-        number, giving results approximately equal to 0. Very large values of
-        length_scale will result in an exponential of values very near zero, yielding
-        1.0.
 
-        For the two input floats
-        .. math::
+        We consider the following cases:
+        1. length scale is :math:`\sqrt{\pi} / 2`:
+        - `floats`: where x and y are floats
+        - `vectors`: where x and y are vectors of the same size
+        - `arrays`: where x and y are arrays of the same shape
 
-            x = 0.5
-
-            y = 2.0
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            ||x - y|| &= |0.5 - 2.0|
-                        &= 1.5
-
-        If we take the ``length_scale`` to be 1.0 we get:
-            k(x, y) &= \exp(- 1.5 / 2.0)
-                    &= 0.472366553
-
+        2. length scale or output scale is degenerate:
+        - `negative_length_scale`: should give same result as positive equivalent
+        - `large_negative_length_scale`: should approximately equal one
+        - `near_zero_length_scale`: should approximately equal zero
+        - `negative_output_scale`: should negate the positive equivalent.
         """
-        # Create the kernel with a positive length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of -1.0
-        kernel = coreax.kernel.LaplacianKernel(length_scale=1.0)
-        self.assertAlmostEqual(kernel.compute(0.5, 2.0), 0.472366553, 6)
-
-        # Create the kernel with a negative length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of 1.0
-        kernel = coreax.kernel.LaplacianKernel(length_scale=-1.0)
-        self.assertAlmostEqual(kernel.compute(0.5, 2.0), 0.472366553, 6)
-
-        # Create the kernel with a large negative length_scale, which should just
-        # yield an exponential to the power of almost zero and hence a result of 1.0
-        kernel = coreax.kernel.LaplacianKernel(length_scale=-10000.0)
-        self.assertEqual(kernel.compute(0.5, 2.0), 1.0)
-
-        # Create the kernel with a small negative length_scale, which should just
-        # yield an exponential to the power of a very large negative number and hence
-        # a result of 0.0
-        kernel = coreax.kernel.LaplacianKernel(length_scale=-0.0000001)
-        self.assertEqual(kernel.compute(0.5, 2.0), 0.0)
-
-    def test_laplacian_kernel_unexpected_output_scale(self) -> None:
-        """
-        Test LaplacianKernel computations with unexpected output_scale inputs.
-
-        This example uses the same length_scale demonstrated in
-        test_laplacian_kernel_unexpected_length_scale. Although a negative output_scale
-        would be unusual, there should be no issue evaluating the kernel with this.
-        """
-        kernel = coreax.kernel.LaplacianKernel(length_scale=1.0, output_scale=1.0)
-        self.assertAlmostEqual(kernel.compute(0.5, 2.0), 0.472366553, 6)
-
-        kernel = coreax.kernel.LaplacianKernel(length_scale=1.0, output_scale=-1.0)
-        self.assertAlmostEqual(kernel.compute(0.5, 2.0), -0.472366553, 6)
-
-    def test_laplacian_kernel_compute_two_floats(self) -> None:
-        r"""
-        Test the class LaplacianKernel distance computations.
-
-        The Laplacian kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||_1/2 * \text{length_scale}^2)`.
-
-        For the two input floats
-        .. math::
-
-            x = 0.5
-
-            y = 2.0
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            ||x - y|| &= |0.5 - 2.0|
-                        &= 1.5
-
-        If we take the ``length_scale`` to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x, y) &= \exp(- 1.5 / \pi)
-                    &= 0.62035410351
-
-        If the ``length_scale`` is instead taken to be :math:`\sqrt{\pi}`, we get:
-            k(x, y) &= \exp(- 1.5 / (2.0\pi))
-                    &= 0.78762561126
-        """
-        # Define data and length_scale
+        kernel = kernel_factory(np.sqrt(np.float32(np.pi) / 2.0), 1.0)
+        mode = request.param
         x = 0.5
         y = 2.0
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
+        if mode == "floats":
+            expected_distances = 0.62035410351
+        elif mode == "vectors":
+            x = 1.0 * np.arange(4)
+            y = x + 1.0
+            expected_distances = 0.279923327
+        elif mode == "arrays":
+            x = np.array(([0, 1, 2, 3], [5, 6, 7, 8]))
+            y = np.array(([1, 2, 3, 4], [5, 6, 7, 8]))
+            expected_distances = np.array(
+                [[0.279923327, 0.00171868172], [0.00613983027, 1.0]]
+            )
+        elif mode == "negative_length_scale":
+            kernel.length_scale = -1
+            expected_distances = 0.472366553
+        elif mode == "large_negative_length_scale":
+            kernel.length_scale = -10000.0
+            expected_distances = 1.0
+        elif mode == "near_zero_length_scale":
+            kernel.length_scale = -0.0000001
+            expected_distances = 0.0
+        elif mode == "negative_output_scale":
+            kernel.length_scale = 1
+            kernel.output_scale = -1
+            expected_distances = -0.472366553
+        else:
+            raise ValueError("Invalid problem mode")
 
-        # Define the expected distance - it should just be a number in this case since
-        # we have floats as inputs, so treat these single data-points in space
-        expected_distance = 0.62035410351
+        return _Problem(x, y, expected_distances, kernel)
 
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-        # Alter the length_scale, and check the JIT decorator catches the update
-        kernel.length_scale = np.sqrt(np.float32(np.pi))
-
-        # Set expected output with this new length_scale
-        expected_distance = 0.78762561126
-
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y, with the new, altered length_scale
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-    def test_laplacian_kernel_compute_two_vectors(self) -> None:
-        r"""
-        Test the class LaplacianKernel distance computations.
-
-        The Laplacian kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||_1/2 * \text{length_scale}^2)`.
-
-        For the two input vectors
-        .. math::
-
-            x = [0, 1, 2, 3]
-
-            y = [1, 2, 3, 4]
-
-        For our choices of ``x`` and ``y``, we have:
-
-        .. math::
-
-            \lVert x - y \rVert_1 &= |0 - 1| + |1 - 2| + |2 - 3| + |3 - 4|
-                        &= 4
-
-        If we take the ``length_scale`` to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x, y) &= \exp(- 4 / \pi)
-                    &= 0.279923327
-        """
-        # Define data and length_scale
-        x = 1.0 * np.arange(4)
-        y = x + 1.0
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
-
-        # Define the expected distance - it should just be a number in this case since
-        # we have 1-dimensional arrays, so treat these as single data-points in space
-        expected_distance = 0.279923327
-
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-
-        # Evaluate the kernel - which computes the distance between the two vectors x
-        # and y
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        self.assertAlmostEqual(output[0, 0], expected_distance, places=5)
-
-    def test_laplacian_kernel_compute_two_arrays(self) -> None:
-        r"""
-        Test the class LaplacianKernel distance computations on arrays.
-
-        The Laplacian kernel is defined as
-        :math:`k(x,y) = \exp (-||x-y||_1/2 * \text{length_scale}^2)`.
-
-        For the two input vectors
-
-        .. math::
-
-            x = [ [0, 1, 2, 3], [5, 6, 7, 8] ]
-
-            y = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
-
-        For our choices of ``x`` and ``y``, we have distances of:
-
-        .. math::
-
-            ||x - y||_1 = [[4, 20], [16, 0]]
-
-        If we take the ``length_scale`` to be :math:`\sqrt{\pi / 2.0}` we get:
-            k(x[0], y[0]) &= \exp(- 4 / \pi)
-                          &= 0.279923327
-            k(x[0], y[1]) &= \exp(- 20 / \pi)
-                          &= 0.00171868172
-            k(x[1], y[0]) &= \exp(- 16 / \pi)
-                          &= 0.00613983027
-            k(x[1], y[1]) &= \exp(- 0 / \pi)
-                          &= 1.0
-
-        """
-        # Define data and length_scale
-        x = np.array(([0, 1, 2, 3], [5, 6, 7, 8]))
-        y = np.array(([1, 2, 3, 4], [5, 6, 7, 8]))
-        length_scale = np.sqrt(np.float32(np.pi) / 2.0)
-
-        # Define the expected Gram matrix
-        expected_distances = np.array(
-            [[0.279923327, 0.00171868172], [0.00613983027, 1.0]]
-        )
-
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-
-        # Evaluate the kernel - which computes the Gram matrix between ``x`` and ``y``
-        output = kernel.compute(x, y)
-
-        # Check the output matches the expected distance
-        np.testing.assert_array_almost_equal(output, expected_distances, decimal=5)
-
-    def test_laplacian_kernel_gradients_wrt_x(self) -> None:
-        r"""
-        Test the class LaplacianKernel gradient computations.
-
-        The Laplacian kernel is defined as
-        :math:`k(x,y) = \exp (-\Vert x-y \rVert_1/2 * \text{length_scale}^2)`. The
-        gradient  of this with respect to ``x`` is:
-
-        .. math:
-            - \operatorname{sgn}{(x - y)}{2length\_scale^{2}}e^{-\frac{\lVert x - y
-              \rVert_1}{2 \text{length_scale}^2}}
-        """
-        # Define some data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to x
-        true_gradients = np.zeros((num_points, num_points, dimension))
+    def expected_grad_x(
+        self, x: ArrayLike, y: ArrayLike, kernel: LaplacianKernel
+    ) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        expected_gradients = np.zeros((num_points, num_points, dimension))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    -np.sign(x[x_idx, :] - y[y_idx, :])
-                    / (2 * length_scale**2)
-                    * np.exp(
-                        -np.linalg.norm(x[x_idx, :] - y[y_idx, :], ord=1)
-                        / (2 * length_scale**2)
-                    )
-                )
-
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-
-        # Evaluate the gradient
-        output = kernel.grad_x(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_laplacian_kernel_grad_x_elementwise(self) -> None:
-        """
-        Test LaplacianKernel element-wise gradient computations w.r.t. ``x``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (
-            -np.sign(x - y)
-            / (2 * length_scale**2)
-            * np.exp(-np.abs(x - y) / (2 * length_scale**2))
-        )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-        output = kernel.grad_x_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_scaled_laplacian_kernel_gradients_wrt_x(self) -> None:
-        # pylint: disable=line-too-long
-        r"""
-        Test the class LaplacianKernel gradient computations; with scaling.
-
-        The scaled Laplacian kernel is defined as
-        :math:`k(x,y) = \text{output_scale}\exp (-\lVert x-y \rVert_1/2 * \text{length_scale}^2)`.
-        The gradient of this with respect to ``x`` is:
-
-        .. math:
-
-            - \text{output_scale}\operatorname{sgn}{(x - y)}{2length\_scale^{2}}e^{-\frac{\lVert x - y\rVert_1}{2 \text{length_scale}^2}}
-        """  # noqa: E501
-        # pylint: enable=line-too-long
-        # Define some data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to x
-        true_gradients = np.zeros((num_points, num_points, dimension))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    -1.0
-                    * output_scale
+                expected_gradients[x_idx, y_idx] = (
+                    -kernel.output_scale
                     * np.sign(x[x_idx, :] - y[y_idx, :])
-                    / (2 * length_scale**2)
+                    / (2 * kernel.length_scale**2)
                     * np.exp(
                         -np.linalg.norm(x[x_idx, :] - y[y_idx, :], ord=1)
-                        / (2 * length_scale**2)
+                        / (2 * kernel.length_scale**2)
                     )
                 )
+        return expected_gradients
 
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
+    def expected_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: LaplacianKernel
+    ) -> np.ndarray:
+        return -self.expected_grad_x(x, y, kernel)
 
-        # Evaluate the gradient
-        output = kernel.grad_x(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_laplacian_kernel_gradients_wrt_y(self) -> None:
-        r"""
-        Test the class LaplacianKernel gradient computations.
-
-        The Laplacian kernel is defined as
-        :math:`k(x,y) = \exp (-\lVert x-y \rVert_1/2 * \text{length_scale}^2)`. The
-        gradient of this with respect to ``y`` is:
-
-        .. math:
-            \operatorname{sgn}{(x - y)}{2length\_scale^{2}}e^{-\frac{\lVert x - y
-              \rVert_1}{2 \text{length_scale}^2}}
-        """
-        # Define some data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Compute the actual gradients of the kernel with respect to y
-        true_gradients = np.zeros((num_points, num_points, dimension))
+    def expected_divergence_x_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: LaplacianKernel
+    ) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        expected_divergence = np.zeros((num_points, num_points))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
-                true_gradients[x_idx, y_idx] = (
-                    np.sign(x[x_idx, :] - y[y_idx, :])
-                    / (2 * length_scale**2)
-                    * np.exp(
-                        -np.linalg.norm(x[x_idx, :] - y[y_idx, :], ord=1)
-                        / (2 * length_scale**2)
-                    )
-                )
-
-        # Create the kernel
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-
-        # Evaluate the gradient
-        output = kernel.grad_y(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(jnp.linalg.norm(true_gradients - output)), 0.0, places=3
-        )
-
-    def test_laplacian_kernel_grad_y_elementwise(self) -> None:
-        """
-        Test LaplacianKernel element-wise gradient computations w.r.t. ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (
-            np.sign(x - y)
-            / (2 * length_scale**2)
-            * np.exp(-np.abs(x - y) / (2 * length_scale**2))
-        )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-        output = kernel.grad_y_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_laplacian_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                expected_output[x_idx, y_idx] = (
-                    -dimension
-                    / (4 * length_scale**4)
-                    * np.exp(
-                        -jnp.linalg.norm(x[x_idx, :] - y[y_idx, :], ord=1)
-                        / (2 * length_scale**2)
-                    )
-                )
-        # Compute output using Kernel class
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_laplacian_div_x_grad_y_elementwise(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of Jacobian w.r.t. ``y`` element-wise.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (
-            -1 / (4 * length_scale**4) * np.exp(-np.abs(x - y) / (2 * length_scale**2))
-        )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.LaplacianKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y_elementwise(x, y)
-
-        self.assertEqual(output, expected_output)
-
-    def test_scaled_laplacian_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``; scaled.
-        """
-        # Setup data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                expected_output[x_idx, y_idx] = (
-                    -1.0
-                    * output_scale
+                expected_divergence[x_idx, y_idx] = (
+                    -kernel.output_scale
                     * dimension
-                    / (4 * length_scale**4)
+                    / (4 * kernel.length_scale**4)
                     * np.exp(
                         -jnp.linalg.norm(x[x_idx, :] - y[y_idx, :], ord=1)
-                        / (2 * length_scale**2)
+                        / (2 * kernel.length_scale**2)
                     )
                 )
-        # Compute output using Kernel class
-        kernel = coreax.kernel.LaplacianKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
-        output = kernel.divergence_x_grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
+        return expected_divergence
 
 
-class TestPCIMQKernel(unittest.TestCase):
-    """
-    Tests related to the PCIMQKernel defined in ``kernel.py``.
-    """
+class TestPCIMQKernel(
+    BaseKernelTest[PCIMQKernel],
+    KernelRowSumTest[PCIMQKernel],
+    KernelGradientTest[PCIMQKernel],
+):
+    """Test ``coreax.kernel.PCIMQKernel``."""
 
-    def test_pcimq_kernel_unexpected_length_scale(self) -> None:
-        # pylint: disable=line-too-long
+    @pytest.fixture
+    def kernel_factory(self):
+        def kernel(length_scale, output_scale):
+            return PCIMQKernel(length_scale, output_scale)
+
+        return kernel
+
+    @override
+    @pytest.fixture(
+        params=[
+            "floats",
+            "vectors",
+            "arrays",
+            "negative_length_scale",
+            "large_negative_length_scale",
+            "near_zero_length_scale",
+            "negative_output_scale",
+        ]
+    )
+    def problem(
+        self,
+        request,
+        kernel_factory: _KernelFactory[PCIMQKernel],
+    ) -> _Problem[PCIMQKernel]:
         r"""
-        Test PCIMQKernel computations with unexpected length_scale inputs.
+        Test problems for the PCIMQ kernel.
 
-        The PCIMQ kernel is defined as
-        :math:`k(x,y) = \frac{1.0}{1.0 / \sqrt(1.0 + ((x - y) / \text{length_scale}) ** 2 / 2.0)}`.
-        Whilst a negative choice of length_scale would be unusual, the kernel can still
-        be evaluated using it. Since the length_scale gets squared in the computation,
-        the negative values should give the same results as the positive values. Very
-        small values of length_scale will result in the exponential of a very large
-        number, giving results approximately equal to 0. Very large values of
-        length_scale will result in an exponential of values very near zero, yielding
-        1.0.
-        """  # noqa: E501
-        # pylint: enable=line-too-long
+        The kernel is defined as
+        :math:`k(x,y) = \frac{1}{\sqrt(1 + ((x - y) / \text{length_scale}) ** 2 / 2)}`.
 
-        # Define input data
-        length_scale = np.e
-        num_points = 10
-        x = np.arange(num_points).reshape(-1, 1)
-        y = x + 1.0
+        We consider the following cases:
+        1. length scale is :math:`\sqrt{\pi} / 2`:
+        - `floats`: where x and y are floats
+        - `vectors`: where x and y are vectors of the same size
+        - `arrays`: where x and y are arrays of the same shape
 
-        # Compute expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx, x_ in enumerate(x):
-            for y_idx, y_ in enumerate(y):
-                expected_output[x_idx, y_idx] = 1.0 / np.sqrt(
-                    1.0 + ((x_[0] - y_[0]) / length_scale) ** 2 / 2.0
-                )
-
-        # Create the kernel with a positive length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of -1.0
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(
-            kernel.compute(x, y), expected_output, decimal=3
-        )
-
-        # Create the kernel with a negative length_scale - this should give the same
-        # answer when evaluating the kernel with a length_scale of 1.0
-        kernel = coreax.kernel.PCIMQKernel(length_scale=-1.0 * length_scale)
-        np.testing.assert_array_almost_equal(
-            kernel.compute(x, y), expected_output, decimal=3
-        )
-
-        # Create the kernel with a large negative length_scale, which should just
-        # yield a result of almost 1
-        kernel = coreax.kernel.PCIMQKernel(length_scale=-10000.0)
-        self.assertEqual(kernel.compute(0.5, 2.0), 1.0)
-
-        # Create the kernel with a small negative length_scale, which should just
-        # yield a result of almost 0
-        kernel = coreax.kernel.PCIMQKernel(length_scale=-0.00000000001)
-        self.assertAlmostEqual(kernel.compute(0.5, 2.0), 0.0)
-
-    def test_pcimq_kernel_unexpected_output_scale(self) -> None:
+        2. length scale or output scale is degenerate:
+        - `negative_length_scale`: should give same result as positive equivalent
+        - `large_negative_length_scale`: should approximately equal one
+        - `near_zero_length_scale`: should approximately equal zero
+        - `negative_output_scale`: should negate the positive equivalent.
         """
-        Test PCIMQKernel computations with unexpected output_scale inputs.
+        kernel = kernel_factory(np.sqrt(np.float32(np.pi) / 2.0), 1.0)
+        mode = request.param
+        x = 0.5
+        y = 2.0
+        if mode == "floats":
+            expected_distances = 0.76333715144
+        elif mode == "vectors":
+            x = 1.0 * np.arange(4)
+            y = x + 1.0
+            expected_distances = 0.66325021409
+        elif mode == "arrays":
+            x = np.array(([0, 1, 2, 3], [5, 6, 7, 8]))
+            y = np.array(([1, 2, 3, 4], [5, 6, 7, 8]))
+            expected_distances = np.array(
+                [[0.66325021409, 0.17452514991], [0.21631125495, 1.0]]
+            )
+        elif mode == "negative_length_scale":
+            kernel.length_scale = -1
+            expected_distances = 0.685994341
+        elif mode == "large_negative_length_scale":
+            kernel.length_scale = -10000.0
+            expected_distances = 1.0
+        elif mode == "near_zero_length_scale":
+            kernel.length_scale = -0.0000001
+            expected_distances = 0.0
+        elif mode == "negative_output_scale":
+            kernel.length_scale = 1
+            kernel.output_scale = -1
+            expected_distances = -0.685994341
+        else:
+            raise ValueError("Invalid problem mode")
 
-        This example uses the same length_scale demonstrated in
-        test_pcimq_kernel_unexpected_length_scale. Although a negative output_scale
-        would be unusual, there should be no issue evaluating the kernel with this.
-        """
-        # Define input data
-        length_scale = np.e
-        num_points = 10
-        x = np.arange(num_points).reshape(-1, 1)
-        y = x + 1.0
+        return _Problem(x, y, expected_distances, kernel)
 
-        # Compute expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx, x_ in enumerate(x):
-            for y_idx, y_ in enumerate(y):
-                expected_output[x_idx, y_idx] = 1.0 / np.sqrt(
-                    1.0 + ((x_[0] - y_[0]) / length_scale) ** 2 / 2.0
-                )
-
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale, output_scale=1.0)
-        np.testing.assert_array_almost_equal(
-            kernel.compute(x, y), expected_output, decimal=3
-        )
-
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale, output_scale=-1.0)
-        np.testing.assert_array_almost_equal(
-            kernel.compute(x, y), -1.0 * expected_output, decimal=3
-        )
-
-    def test_pcimq_kernel_compute(self) -> None:
-        # pylint: disable=line-too-long
-        r"""
-        Test the class PCIMQKernel distance computations.
-
-        The PCIMQ kernel is defined as
-        :math:`k(x,y) = \frac{1.0}{1.0 / \sqrt(1.0 + ((x - y) / \text{length_scale}) ** 2 / 2.0)}`.
-        """  # noqa: E501
-        # pylint: enable=line-too-long
-        # Define input data
-        length_scale = np.e
-        num_points = 10
-        x = np.arange(num_points).reshape(-1, 1)
-        y = x + 1.0
-
-        # Compute expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx, x_ in enumerate(x):
-            for y_idx, y_ in enumerate(y):
-                expected_output[x_idx, y_idx] = 1.0 / np.sqrt(
-                    1.0 + ((x_[0] - y_[0]) / length_scale) ** 2 / 2.0
-                )
-
-        # Compute distance using the kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.compute(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_pcimq_kernel_gradients_wrt_x(self) -> None:
-        r"""
-        Test the class PCIMQ gradient computations with respect to ``x``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points, dimension))
+    def expected_grad_x(
+        self, x: ArrayLike, y: ArrayLike, kernel: PCIMQKernel
+    ) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        expected_gradients = np.zeros((num_points, num_points, dimension))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
-                expected_output[x_idx, y_idx] = -(x[x_idx, :] - y[y_idx, :]) / (
-                    1 + np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2
-                ) ** (3 / 2)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.grad_x(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_pcimq_kernel_grad_x_elementwise(self) -> None:
-        """
-        Test the PCIMQ kernel element-wise gradient computations w.r.t. ``x``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = -(x - y) / (1 + np.abs(x - y) ** 2) ** (3 / 2)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.grad_x_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_pcimq_kernel_gradients_wrt_y(self) -> None:
-        """
-        Test the class PCIMQ gradient computations with respect to ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points, dimension))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                expected_output[x_idx, y_idx] = (x[x_idx, :] - y[y_idx, :]) / (
-                    1 + np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2
-                ) ** (3 / 2)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_pcimq_kernel_grad_y_elementwise(self) -> None:
-        """
-        Test the class PCIMQ element-wise gradient computations with respect to ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        expected_output = (x - y) / (1 + np.abs(x - y) ** 2) ** (3 / 2)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.grad_y_elementwise(x, y)
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_scaled_pcimq_kernel_gradients_wrt_y(self) -> None:
-        """
-        Test the class PCIMQ gradient computations with respect to ``y``; with scaling.
-        """
-        # Setup data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points, dimension))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                expected_output[x_idx, y_idx] = (
-                    output_scale
-                    / (2 * length_scale**2)
+                scaling = 2 * kernel.length_scale**2
+                mq_array = np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2 / scaling
+                primal = kernel.output_scale / np.sqrt(1 + mq_array)
+                expected_gradients[x_idx, y_idx] = (
+                    -kernel.output_scale
+                    / scaling
                     * (x[x_idx, :] - y[y_idx, :])
-                    / (
-                        1
-                        + (np.linalg.norm(x[x_idx, :] - y[y_idx, :]) ** 2)
-                        / (2 * length_scale**2)
-                    )
-                    ** (3 / 2)
+                    * (primal / kernel.output_scale) ** 3
                 )
+        return expected_gradients
 
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
-        output = kernel.grad_y(x, y)
+    def expected_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: PCIMQKernel
+    ) -> np.ndarray:
+        return -self.expected_grad_x(x, y, kernel)
 
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_pcimq_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
-        for x_idx in range(x.shape[0]):
-            for y_idx in range(y.shape[0]):
-                dot_product = np.dot(
-                    x[x_idx, :] - y[y_idx, :], x[x_idx, :] - y[y_idx, :]
-                )
-                denominator = (1 + dot_product) ** (3 / 2)
-                expected_output[x_idx, y_idx] = (
-                    dimension / denominator - 3 * dot_product / denominator ** (5 / 3)
-                )
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y(x, y)
-
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
-
-    def test_pcimq_div_x_grad_y_elementwise(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of Jacobian w.r.t. ``y`` element-wise.
-        """
-        # Setup data
-        length_scale = 1 / np.sqrt(2)
-        random_data_generation_key = 1_989
-
-        generator = np.random.default_rng(random_data_generation_key)
-        x = generator.random((1, 1))
-        y = generator.random((1, 1))
-
-        # Define expected output
-        denominator = (1 + (x - y) ** 2) ** (3 / 2)
-        expected_output = 1 / denominator - 3 * (x - y) ** 2 / denominator ** (5 / 3)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(length_scale=length_scale)
-        output = kernel.divergence_x_grad_y_elementwise(x, y)
-
-        self.assertAlmostEqual(output, expected_output, places=6)
-
-    def test_scaled_pcimq_div_x_grad_y(self) -> None:
-        """
-        Test the divergence w.r.t. ``x`` of kernel Jacobian w.r.t. ``y``; scaled.
-        """
-        # Setup data
-        length_scale = 1 / np.pi
-        output_scale = np.e
-        num_points = 10
-        dimension = 2
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
-        x = generator.random((num_points, dimension))
-        y = generator.random((num_points, dimension))
-
-        # Define expected output
-        expected_output = np.zeros((num_points, num_points))
+    def expected_divergence_x_grad_y(
+        self, x: ArrayLike, y: ArrayLike, kernel: PCIMQKernel
+    ) -> np.ndarray:
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+        num_points, dimension = x.shape
+        length_scale = kernel.length_scale
+        output_scale = kernel.output_scale
+        expected_divergence = np.zeros((num_points, num_points))
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
                 dot_product = np.dot(
@@ -2014,7 +687,7 @@ class TestPCIMQKernel(unittest.TestCase):
                 kernel_scaled = output_scale / (
                     (1 + dot_product / (2 * length_scale**2)) ** (1 / 2)
                 )
-                expected_output[x_idx, y_idx] = (
+                expected_divergence[x_idx, y_idx] = (
                     output_scale
                     / (2 * length_scale**2)
                     * (
@@ -2025,82 +698,38 @@ class TestPCIMQKernel(unittest.TestCase):
                         / (2 * length_scale**2)
                     )
                 )
-        # Compute output using Kernel class
-        kernel = coreax.kernel.PCIMQKernel(
-            length_scale=length_scale, output_scale=output_scale
-        )
-        output = kernel.divergence_x_grad_y(x, y)
 
-        # Check output matches expected
-        np.testing.assert_array_almost_equal(output, expected_output, decimal=3)
+        return expected_divergence
 
 
-class TestSteinKernel(unittest.TestCase):
-    """
-    Tests related to the SteinKernel defined in ``kernel.py``.
-    """
+class TestSteinKernel(BaseKernelTest[SteinKernel]):
+    """Test ``coreax.kernel.SteinKernel``."""
 
-    def test_stein_kernel_computation(self) -> None:
-        r"""
-        Test computation of the SteinKernel.
+    @pytest.fixture
+    def kernel_factory(self) -> _KernelFactory[SteinKernel]:
+        def kernel(length_scale, output_scale):
+            base_kernel = PCIMQKernel(length_scale, output_scale)
+            return SteinKernel(base_kernel=base_kernel, score_function=jnp.negative)
 
-        Due to the complexity of the Stein kernel, we check the size of the output
-        matches the expected size, not the numerical values in the output array itself.
-        """
-        # Setup some data
+        return kernel
+
+    @pytest.fixture
+    def problem(
+        self,
+        request,
+        kernel_factory: _KernelFactory[SteinKernel],
+    ) -> _Problem[SteinKernel]:
+        """Test problem for the Stein kernel."""
+        length_scale = 1 / np.sqrt(2)
+        kernel = kernel_factory(length_scale, 1.0)
+        score_function = kernel.score_function
+        beta = 0.5
         num_points_x = 10
         num_points_y = 5
         dimension = 2
-        length_scale = 1 / np.sqrt(2)
-
-        def score_function(x_: ArrayLike) -> Array:
-            """
-            Compute a simple, example score function for testing purposes.
-
-            :param x_: Point or points at which we wish to evaluate the score function
-            :return: Evaluation of the score function at ``x_``
-            """
-            return -x_
-
-        # Setup data
-        random_data_generation_key = 1_989
-        generator = np.random.default_rng(random_data_generation_key)
-
+        generator = np.random.default_rng(1_989)
         x = generator.random((num_points_x, dimension))
         y = generator.random((num_points_y, dimension))
-
-        # Set expected output sizes
-        expected_size = (10, 5)
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SteinKernel(
-            base_kernel=coreax.kernel.PCIMQKernel(length_scale=length_scale),
-            score_function=score_function,
-        )
-        output = kernel.compute(x, y)
-
-        # Check output sizes match the expected
-        self.assertEqual(output.shape, expected_size)
-
-    def test_stein_kernel_element_computation(self) -> None:
-        r"""
-        Test computation of a single element of the SteinKernel.
-        """
-        # Setup some data
-        num_points_x = 10
-        num_points_y = 5
-        dimension = 2
-        length_scale = 1 / np.sqrt(2)
-        beta = 0.5
-
-        def score_function(x_: ArrayLike) -> Array:
-            """
-            Compute a simple, example score function for testing purposes.
-
-            :param x_: Point or points at which we wish to evaluate the score function
-            :return: Evaluation of the score function at ``x_``
-            """
-            return -x_
 
         def k_x_y(x_input, y_input):
             r"""
@@ -2134,125 +763,21 @@ class TestSteinKernel(unittest.TestCase):
             """
             norm_sq = np.linalg.norm(x_input - y_input) ** 2
             n = -3 * norm_sq / (1 + norm_sq) ** 2.5
-            m = (
-                2
-                * beta
-                * (
-                    dimension
-                    + np.dot(
-                        score_function(x_input) - score_function(y_input),
-                        x_input - y_input,
-                    )
-                )
-                / (1 + norm_sq) ** 1.5
+            dot_prod = np.dot(
+                score_function(x_input) - score_function(y_input),
+                x_input - y_input,
             )
+            m = 2 * beta * (dimension + dot_prod) / (1 + norm_sq) ** 1.5
             r = (
                 np.dot(score_function(x_input), score_function(y_input))
                 / (1 + norm_sq) ** 0.5
             )
             return n + m + r
 
-        # Setup data
-        generator = np.random.default_rng(1_989)
-        x = generator.random((num_points_x, dimension))
-        y = generator.random((num_points_y, dimension))
-
-        # Compute output using Kernel class
-        kernel = coreax.kernel.SteinKernel(
-            base_kernel=coreax.kernel.PCIMQKernel(length_scale=length_scale),
-            score_function=score_function,
-        )
-
-        # Compute the output step-by-step with the element method
         expected_output = np.zeros([x.shape[0], y.shape[0]])
-        output = kernel.compute(x, y)
         for x_idx in range(x.shape[0]):
             for y_idx in range(y.shape[0]):
                 # Compute via our hand-coded kernel evaluation
                 expected_output[x_idx, y_idx] = k_x_y(x[x_idx, :], y[y_idx, :])
 
-        # Check output matches the expected
-        np.testing.assert_array_almost_equal(output, expected_output)
-
-    def test_stein_kernel_invalid_base_kernel_missing_divergence(self) -> None:
-        r"""
-        Test how the SteinKernel handles an invalid base kernel being passed.
-
-        The base kernel here is missing a method to compute the divergence of the data.
-        """
-        # Setup some data
-        num_points_x = 10
-        num_points_y = 5
-        dimension = 2
-
-        def score_function(x_: ArrayLike) -> Array:
-            """
-            Compute a simple, example score function for testing purposes.
-
-            :param x_: Point or points at which we wish to evaluate the score function
-            :return: Evaluation of the score function at ``x_``
-            """
-            return -x_
-
-        # Setup data
-        generator = np.random.default_rng(1_989)
-        x = generator.random((num_points_x, dimension))
-        y = generator.random((num_points_y, dimension))
-
-        # Compute output using Kernel class - since the base kernel does not have a
-        # divergence method, it should raise an attribute error.
-        kernel = coreax.kernel.SteinKernel(
-            base_kernel=KernelNoDivergenceMethod(a=1.0),
-            score_function=score_function,
-        )
-        with self.assertRaisesRegex(
-            AttributeError, "object has no attribute 'divergence_x_grad_y_elementwise'"
-        ):
-            kernel.compute(x, y)
-
-    def test_stein_kernel_invalid_base_kernel_no_pytree(self) -> None:
-        r"""
-        Test how the SteinKernel handles an invalid base kernel being passed.
-
-        The base kernel here is missing a method to flatten a pytree, and then a method
-        to unflatten a pytree.
-        """
-
-        def score_function(x_: ArrayLike) -> Array:
-            """
-            Compute a simple, example score function for testing purposes.
-
-            :param x_: Point or points at which we wish to evaluate the score function
-            :return: Evaluation of the score function at ``x_``
-            """
-            return -x_
-
-        # Create the Kernel class - since the base kernel does not have tree_flatten
-        # method, the code should raise an attribute error and inform the user.
-        with self.assertRaises(AttributeError) as error_raised:
-            coreax.kernel.SteinKernel(
-                base_kernel=KernelNoTreeFlatten(a=1.0),
-                score_function=score_function,
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "base_kernel must have the method tree_flatten implemented",
-        )
-
-        # Create the Kernel class - since the base kernel does not have tree_unflatten
-        # method, the code should raise an attribute error and inform the user.
-        with self.assertRaises(AttributeError) as error_raised:
-            coreax.kernel.SteinKernel(
-                base_kernel=KernelNoTreeUnflatten(a=1.0),
-                score_function=score_function,
-            )
-
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "base_kernel must have the method tree_unflatten implemented",
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        return _Problem(x, y, expected_output, kernel)


### PR DESCRIPTION
### PR Type
Closes #542

- Feature
- Refactoring (no functional changes)
- Tests

### Description
Significantly reduces the LOCs and enhances modularity of the tests. This should help improve test consistency and reduce the implementation burden for testing any future additions to `kernel.py`.

### How Has This Been Tested?
The new tests pass.

### Does this PR introduce a breaking change?
Removes the following redundant/ineffective tests:
- `test_approximator_valid`: test did not perform effective checks
- `test_stein_kernel_computation`: redundant overlap with `test_stein_kernel_element_computation`
- `test_stein_kernel_invalid_base_kernel_missing_divergence` and `test_stein_kernel_invalid_base_kernel_no_pytree` are replaced with a single check of `InvalidKernel`

Modifies the following logic:
- ~~`SteinKernel` now only checks on a call to `compute_elementwise` if the `base_kernel` attribute is an instance of `Kernel` (as required)~~



### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
