### PR TITLE
feat: utilise pytest for `test_refine`

### DIFF
--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -132,7 +132,7 @@ class RefineTestCase(ABC):
             ),
             _RefineProblem(
                 array=jnp.asarray([[0, 0], [1, 1], [2, 2]]),
-                test_indices=list(itertools.combinations(range(3), 2)),
+                test_indices=[(2, 2)],
                 best_indices=[{0, 2}],
             ),
         ],
@@ -154,7 +154,8 @@ class RefineTestCase(ABC):
         method returns a coresubset with indices equal to a set in ``best_indices``.
 
         - The ``no_unique_best`` case tests scenarios with multiple "best" solutions.
-        - The ``unique_best`` cases tests scenarios with a unique "best" solution.
+        - The ``unique_best`` case tests scenarios with a unique "best" solution. This
+        unique solution is expected even for random/greedy refinement methods.
 
         When ``use_cached_row_sum_mean=True``, we expect the corresponding cached value
         in the coreset object to be used by refine, otherwise, we expect the kernel's


### PR DESCRIPTION
### PR Type
Closes #546

- Feature
- Refactoring (no functional changes)
- Tests

### Description
Reduces the LOC and enhances the modularity of the tests. This should help improve test consistency and reduce the implementation burden for testing any future additions to refine.py.

### How Has This Been Tested?
The new tests pass.

### Does this PR introduce a breaking change?
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
