### PR TITLE
fix: use fully qualified path for herding_refine lookup

### DIFF
--- a/tests/integration/test_herding_refine.py
+++ b/tests/integration/test_herding_refine.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import call, patch
 
-from herding_refine_weighted import main as herding_refine_main
+from examples.herding_refine_weighted import main as herding_refine_main
 
 # Integration tests are split across several files, to allow serial calls and avoid
 # sharing of JIT caches between tests. As a result, ignore the pylint warnings for


### PR DESCRIPTION
### PR Type
- Bugfix

### Description
Fixes the import path so the following command succeeds `pytest tests/integration`.
Note: we do not run the integration tests in the GitHub workflows so this was not picked up when merged in #539. Pull #550 provides new checks that would pick up such a bug in any future pulls.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
