### PR TITLE
Fix: import typo in test_herding_refine.py

### DIFF
--- a/tests/integration/test_herding_refine.py
+++ b/tests/integration/test_herding_refine.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import call, patch
 
-from herding_refine_weighted import main as herding_refine_main
+from examples.herding_refine_weighted import main as herding_refine_main
 
 # Integration tests are split across several files, to allow serial calls and avoid
 # sharing of JIT caches between tests. As a result, ignore the pylint warnings for


### PR DESCRIPTION
Resolves #552

### PR Type

- Bugfix
- Tests

### Description

This PR resolves an import error in the file test_herding_refine.py. 

### How Has This Been Tested?

test_herding_refine.py tests now pass without error. No new errors occur.

### Does this PR introduce a breaking change?

No.

### Screenshots



### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
