### PR TITLE
fix: handle very rare `jit_test` test failures

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -85,6 +85,7 @@ pytrees
 quickstart
 rcfile
 rect
+rerunfailures
 rightarrow
 rtol
 samp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "opencv-python",
     "pyqt5",
     "pytest-cov",
+    "pytest-rerunfailures",
     "scipy",
 ]
 # Compile documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -60,6 +60,7 @@ pyqt5-sip==12.13.0; python_version >= '3.7'
 pyroma==4.2; python_version >= '3.7'
 pytest==7.4.4; python_version >= '3.7'
 pytest-cov==4.1.0; python_version >= '3.7'
+pytest-rerunfailures==14.0
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyyaml==6.0.1; python_version >= '3.6'
 requests==2.31.0; python_version >= '3.7'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -51,6 +51,7 @@ pyqt5-qt5==5.15.2
 pyqt5-sip==12.13.0; python_version >= '3.7'
 pytest==7.4.4; python_version >= '3.7'
 pytest-cov==4.1.0; python_version >= '3.7'
+pytest-rerunfailures==14.0
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tomli==2.0.1; python_version < '3.11'


### PR DESCRIPTION
### PR Type
Closes #525

- Bugfix
- Tests

### Description
Handles the very rare failures of the `jit_test` test by utilising `pytest.mark.flaky` from `pytest-rerunfailures`, which re-runs the test on the event of a failure (up to three times).

Now uses pytest parameterisation such that each individual scenario can be re-run if failed, rather than re-running until every scenario passes at once (reducing the probability of continued failure after three re-runs).

Additionally, provides an explicit check to ensure the function is only traced once (the JIT compiled function is being called on the second call) to supplement the implicit checks performed in checked the timings.

### How Has This Been Tested?
The new/updated unit tests pass.

### Does this PR introduce a breaking change?
No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
