### PR TITLE
feat!: introduce Gramian row-mean

### DIFF
--- a/.cspell/custom_misc.txt
+++ b/.cspell/custom_misc.txt
@@ -13,6 +13,7 @@ docstrings
 elementwise
 forall
 GCHQ
+Gramian
 kbar
 kdtree
 kernelised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `coreax.weights.SBQ` to `coreax.weights.SBQWeightsOptimiser` and added deprecation warning.
 - `requirements-*.txt` will no longer be updated frequently, thereby providing stable versions.
 - Single requirements files covering all supported Python versions.
+- All references to `kernel_matrix_row_{sum,mean}` have been replaced with `Gramian row-mean`.
 
 ### Removed
 - Bash script to run integration tests has been removed. `pytest tests/integration` should now work as expected.
+- Tests for `coreax.kernels.Kernel.{calculate, update}_kernel_matrix_row_sum`.
+- `coreax.util.KernelComputeType`; use `Callable[[ArrayLike, ArrayLike], Array]` instead.
+- `coreax.kernels.Kernel.calculate_kernel_matrix_row_{sum,mean}`; use `coreax.kernels.Kernel.gramian_row_mean`.
+- `coreax.kernels.Kernel.updated_kernel_matrix_row_sum`; use `coreax.kernels.Kernel.gramian_row_mean` if possible.
+
 
 ### Deprecated
 
 - All uses of `coreax.weights.MMD` should be replaced with `coreax.weights.MMDWeightsOptimiser`.
 - All uses of `coreax.weights.SBQ` should be replaced with `coreax.weights.SBQWeightsOptimiser`.
+
 
 ## [0.1.0] - 2024-02-16
 

--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -16,9 +16,9 @@ r"""
 Classes and associated functionality to approximate kernels.
 
 When a dataset is very large, methods which have to evaluate all pairwise combinations
-of the data, such as :meth:`~coreax.kernel.Kernel.gramian_row_mean`,
-can become prohibitively expensive. To reduce this computational cost, such methods can
-instead be approximated (providing suitable approximation error can be achieved).
+of the data, such as :meth:`~coreax.kernel.Kernel.gramian_row_mean`, can become
+prohibitively expensive. To reduce this computational cost, such methods can instead be
+approximated (providing suitable approximation error can be achieved).
 
 The :class:`ApproximateKernel`\ s in this module provide the functionality required to
 override specific methods of a ``base_kernel`` with their approximate counterparts.
@@ -177,8 +177,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
         Gramian row-mean.
 
         :param x: Data matrix, :math:`n \times d`
-        :param max_size: Size of matrix block to process
-        :return: Approximation of the base kernel's Gramian row mean
+        :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
         data = jnp.atleast_2d(x)
@@ -218,8 +217,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
         implementation used can be found `here <https://github.com/gchq/annchor>`_.
 
         :param x: Data matrix, :math:`n \times d`
-        :param max_size: Size of matrix block to process
-        :return: Approximation of the base kernel's Gramian row mean
+        :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
         data = jnp.atleast_2d(x)
@@ -275,8 +273,7 @@ class NystromApproximateKernel(RandomRegressionKernel):
         in :cite:`chatalic2022nystrom` is computed using this subset.
 
         :param x: Data matrix, :math:`n \times d`
-        :param max_size: Size of matrix block to process
-        :return: Approximation of the base kernel's Gramian row mean
+        :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
         data = jnp.atleast_2d(x)

--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -16,7 +16,7 @@ r"""
 Classes and associated functionality to approximate kernels.
 
 When a dataset is very large, methods which have to evaluate all pairwise combinations
-of the data, such as :meth:`~coreax.kernel.Kernel.calculate_kernel_matrix_row_sum_mean`,
+of the data, such as :meth:`~coreax.kernel.Kernel.gramian_row_mean`,
 can become prohibitively expensive. To reduce this computational cost, such methods can
 instead be approximated (providing suitable approximation error can be achieved).
 
@@ -107,9 +107,9 @@ class ApproximateKernel(CompositeKernel):
 
     Provides approximations of the methods in the ``base_kernel``.
 
-    The :meth:`~coreax.kernel.Kernel.calculate_kernel_matrix_row_sum` method is
-    particularly amenable to approximation, with significant performance improvements
-    possible depending on the acceptable levels of error.
+    The :meth:`~coreax.kernel.Kernel.gramian_row_mean` method is particularly amenable
+    to approximation, with significant performance improvements possible depending on
+    the acceptable levels of error.
 
     :param base_kernel: a :class:`~coreax.kernel.Kernel` whose attributes/methods are
         to be approximated
@@ -159,8 +159,8 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
     """
     Approximate a base kernel via random subset selection.
 
-    Only the kernel matrix row sum mean is approximated here, all other methods
-    are inherited directly from the ``base_kernel``.
+    Only the Gramian row-mean is approximated here, all other methods are inherited
+    directly from the ``base_kernel``.
 
     :param base_kernel: a :class:`~coreax.kernel.Kernel` whose attributes/methods are
         to be approximated
@@ -169,19 +169,18 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def calculate_kernel_matrix_row_sum_mean(
-        self, x: ArrayLike, max_size: int = 10_000
-    ) -> Array:
+    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
         r"""
-        Calculate the kernel matrix row sum mean by Monte Carlo approximation.
+        Approximate the Gramian row-mean by Monte-Carlo sampling.
 
-        A uniform random subset of ``x`` is used to approximate the kernel matrix row
-        sum mean.
+        A uniform random subset of ``x`` is used to approximate the base kernel's
+        Gramian row-mean.
 
         :param x: Data matrix, :math:`n \times d`
         :param max_size: Size of matrix block to process
-        :return: Approximation of the kernel matrix row sum
+        :return: Approximation of the base kernel's Gramian row mean
         """
+        del kwargs
         data = jnp.atleast_2d(x)
         num_data_points = len(data)
         key = self.random_key
@@ -200,8 +199,8 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
     r"""
     Approximate a base kernel via random kernel regression on ANNchor selected points.
 
-    Only the kernel matrix row sum mean is approximated here, all other methods
-    are inherited directly from the ``base_kernel``.
+    Only the base kernel's Gramian row-mean is approximated here, all other methods are
+    inherited directly from the ``base_kernel``.
 
     :param base_kernel: a :class:`~coreax.kernel.Kernel` whose attributes/methods are
         to be approximated
@@ -210,20 +209,19 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def calculate_kernel_matrix_row_sum_mean(
-        self, x: ArrayLike, max_size: int = 10_000
-    ) -> Array:
+    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
         r"""
-        Calculate the kernel matrix row sum mean by random regression on ANNchor points.
+        Approximate the Gramian row-mean by random regression on ANNchor points.
 
         A subset of ``x`` is selected via the ANNchor approach and random kernel
-        regression used to approximate the kernel matrix row sum mean. The ANNchor
+        regression used to approximate the base kernel's Gramian row-mean. The ANNchor
         implementation used can be found `here <https://github.com/gchq/annchor>`_.
 
         :param x: Data matrix, :math:`n \times d`
         :param max_size: Size of matrix block to process
-        :return: Approximation of the kernel matrix row sum
+        :return: Approximation of the base kernel's Gramian row mean
         """
+        del kwargs
         data = jnp.atleast_2d(x)
         num_data_points = len(data)
         features = jnp.zeros((num_data_points, self.num_kernel_points))
@@ -257,32 +255,30 @@ class NystromApproximateKernel(RandomRegressionKernel):
     """
     Approximate a base kernel via Nystrom approximation.
 
-    Only the kernel matrix row sum mean is approximated here, all other methods
+    Only the base kernel's Gramian row-mean is approximated here, all other methods
     are inherited directly from the ``base_kernel``.
 
     :param base_kernel: a :class:`~coreax.kernel.Kernel` whose attributes/methods are
         to be approximated
     :param random_key: Key for random number generation
-    :param kernel: A :class:`~coreax.kernel.Kernel` object
     :param num_kernel_points: Number of kernel evaluation points
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def calculate_kernel_matrix_row_sum_mean(
-        self, x: ArrayLike, max_size: int = 10_000
-    ) -> Array:
+    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
         r"""
-        Calculate the kernel matrix row sum mean by Nystrom approximation.
+        Approximate the Gramian row-mean by Nystrom approximation.
 
         We consider a :math:`n \times d` dataset, and wish to use an :math:`m \times d`
-        subset of this to approximate the kernel matrix row sum mean. The ``m`` points
-        are selected uniformly at random, and the Nystrom estimator, as defined in
-        :cite:`chatalic2022nystrom` is computed using this subset.
+        subset of this to approximate the base kernel's Gramian row-mean. The ``m``
+        points are selected uniformly at random, and the Nystrom estimator, as defined
+        in :cite:`chatalic2022nystrom` is computed using this subset.
 
         :param x: Data matrix, :math:`n \times d`
         :param max_size: Size of matrix block to process
-        :return: Approximation of the kernel matrix row sum
+        :return: Approximation of the base kernel's Gramian row mean
         """
+        del kwargs
         data = jnp.atleast_2d(x)
         num_data_points = len(data)
         feature_idx = _random_indices(

--- a/coreax/reduction.py
+++ b/coreax/reduction.py
@@ -110,7 +110,7 @@ class Coreset(ABC):
         Indices of :attr:`coreset` points in :attr:`original_data`, if applicable. The
         order matches the rows of :attr:`coreset`.
         """
-        self.kernel_matrix_row_sum_mean: ArrayLike | None = None
+        self.gramian_row_mean: ArrayLike | None = None
         r"""
         Mean vector over rows for the Gram matrix, a :math:`1 \times n` array. If
         :meth:`fit_to_size` calculates this, it will be saved here automatically to save
@@ -135,7 +135,7 @@ class Coreset(ABC):
         new_obj.original_data = None
         new_obj.coreset = None
         new_obj.coreset_indices = None
-        new_obj.kernel_matrix_row_sum_mean = None
+        new_obj.gramian_row_mean = None
         return new_obj
 
     def fit(

--- a/coreax/refine.py
+++ b/coreax/refine.py
@@ -246,7 +246,7 @@ class RefineRegular(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param gramian_row_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row-mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -442,7 +442,7 @@ class RefineRandom(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param gramian_row_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row-mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -626,7 +626,7 @@ class RefineReverse(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param gramian_row_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row-mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array

--- a/coreax/refine.py
+++ b/coreax/refine.py
@@ -166,12 +166,10 @@ class RefineRegular(Refine):
             original_array, original_array
         )
 
-        # If not already done on Coreset, calculate kernel_matrix_row_sum_mean
-        kernel_matrix_row_sum_mean = coreset.kernel_matrix_row_sum_mean
-        if kernel_matrix_row_sum_mean is None:
-            kernel_matrix_row_sum_mean = (
-                coreset.kernel.calculate_kernel_matrix_row_sum_mean(original_array)
-            )
+        # If not already done on Coreset, calculate gramian_row_mean
+        gramian_row_mean = coreset.gramian_row_mean
+        if gramian_row_mean is None:
+            gramian_row_mean = coreset.kernel.gramian_row_mean(original_array)
 
         coreset_indices = jnp.asarray(coreset_indices)
         num_points_in_coreset = len(coreset_indices)
@@ -179,7 +177,7 @@ class RefineRegular(Refine):
             self._refine_body,
             x=original_array,
             kernel=coreset.kernel,
-            kernel_matrix_row_sum_mean=kernel_matrix_row_sum_mean,
+            gramian_row_mean=gramian_row_mean,
             kernel_gram_matrix_diagonal=kernel_gram_matrix_diagonal,
         )
         coreset_indices = lax.fori_loop(0, num_points_in_coreset, body, coreset_indices)
@@ -194,7 +192,7 @@ class RefineRegular(Refine):
         coreset_indices: ArrayLike,
         x: ArrayLike,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> Array:
         r"""
@@ -205,7 +203,7 @@ class RefineRegular(Refine):
         :param x: Original :math:`n \times d` dataset
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: Mean vector over rows for the Gram matrix,
+        :param gramian_row_mean: Mean vector over rows for the Gram matrix,
             a :math:`1 \times n` array
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal, a :math:`1 \times n`
             array
@@ -218,7 +216,7 @@ class RefineRegular(Refine):
                 coreset_indices=coreset_indices,
                 x=x,
                 kernel=kernel,
-                kernel_matrix_row_sum_mean=kernel_matrix_row_sum_mean,
+                gramian_row_mean=gramian_row_mean,
                 kernel_gram_matrix_diagonal=kernel_gram_matrix_diagonal,
             ).argmax()
         )
@@ -232,7 +230,7 @@ class RefineRegular(Refine):
         coreset_indices: ArrayLike,
         x: ArrayLike,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> Array:
         r"""
@@ -248,7 +246,7 @@ class RefineRegular(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -257,14 +255,14 @@ class RefineRegular(Refine):
         coreset_indices = jnp.asarray(coreset_indices)
         num_points_in_coreset = len(coreset_indices)
         x = jnp.asarray(x)
-        kernel_matrix_row_sum_mean = jnp.asarray(kernel_matrix_row_sum_mean)
+        gramian_row_mean = jnp.asarray(gramian_row_mean)
         return (
             kernel.compute(x[coreset_indices], x[i]).sum()
             - kernel.compute(x, x[coreset_indices]).sum(axis=1)
             + kernel.compute(x, x[i])[:, 0]
             - kernel_gram_matrix_diagonal
         ) / (num_points_in_coreset**2) - (
-            kernel_matrix_row_sum_mean[i] - kernel_matrix_row_sum_mean
+            gramian_row_mean[i] - gramian_row_mean
         ) / num_points_in_coreset
 
 
@@ -335,12 +333,10 @@ class RefineRandom(Refine):
             original_array, original_array
         )
 
-        # If not already done on Coreset, calculate kernel_matrix_row_sum_mean
-        kernel_matrix_row_sum_mean = coreset.kernel_matrix_row_sum_mean
-        if kernel_matrix_row_sum_mean is None:
-            kernel_matrix_row_sum_mean = (
-                coreset.kernel.calculate_kernel_matrix_row_sum_mean(original_array)
-            )
+        # If not already done on Coreset, calculate gramian_row_mean
+        gramian_row_mean = coreset.gramian_row_mean
+        if gramian_row_mean is None:
+            gramian_row_mean = coreset.kernel.gramian_row_mean(original_array)
 
         coreset_indices = jnp.asarray(coreset_indices)
         num_points_in_coreset = len(coreset_indices)
@@ -360,7 +356,7 @@ class RefineRandom(Refine):
             x=original_array,
             n_cand=n_cand,
             kernel=coreset.kernel,
-            kernel_matrix_row_sum_mean=kernel_matrix_row_sum_mean,
+            gramian_row_mean=gramian_row_mean,
             kernel_gram_matrix_diagonal=kernel_gram_matrix_diagonal,
         )
         _, coreset_indices = lax.fori_loop(
@@ -377,7 +373,7 @@ class RefineRandom(Refine):
         x: ArrayLike,
         n_cand: int,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> tuple[coreax.util.KeyArray, Array]:
         r"""
@@ -390,7 +386,7 @@ class RefineRandom(Refine):
         :param n_cand: Number of candidates for comparison
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: Mean vector over rows for the Gram matrix,
+        :param gramian_row_mean: Mean vector over rows for the Gram matrix,
             a :math:`1 \times n` array
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -408,7 +404,7 @@ class RefineRandom(Refine):
             coreset_indices,
             x=x,
             kernel=kernel,
-            kernel_matrix_row_sum_mean=kernel_matrix_row_sum_mean,
+            gramian_row_mean=gramian_row_mean,
             kernel_gram_matrix_diagonal=kernel_gram_matrix_diagonal,
         )
         coreset_indices = lax.cond(
@@ -431,7 +427,7 @@ class RefineRandom(Refine):
         coreset_indices: ArrayLike,
         x: ArrayLike,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> Array:
         r"""
@@ -446,7 +442,7 @@ class RefineRandom(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -454,7 +450,7 @@ class RefineRandom(Refine):
         """
         coreset_indices = jnp.asarray(coreset_indices)
         x = jnp.asarray(x)
-        kernel_matrix_row_sum_mean = jnp.asarray(kernel_matrix_row_sum_mean)
+        gramian_row_mean = jnp.asarray(gramian_row_mean)
         kernel_gram_matrix_diagonal = jnp.asarray(kernel_gram_matrix_diagonal)
         num_points_in_coreset = len(coreset_indices)
 
@@ -464,8 +460,7 @@ class RefineRandom(Refine):
             + kernel.compute(x[candidate_indices, :], x[i])[:, 0]
             - kernel_gram_matrix_diagonal[candidate_indices]
         ) / (num_points_in_coreset**2) - (
-            kernel_matrix_row_sum_mean[i]
-            - kernel_matrix_row_sum_mean[candidate_indices]
+            gramian_row_mean[i] - gramian_row_mean[candidate_indices]
         ) / num_points_in_coreset
 
     @jit
@@ -549,12 +544,10 @@ class RefineReverse(Refine):
             original_array, original_array
         )
 
-        # If not already done on Coreset, calculate kernel_matrix_row_sum_mean
-        kernel_matrix_row_sum_mean = coreset.kernel_matrix_row_sum_mean
-        if kernel_matrix_row_sum_mean is None:
-            kernel_matrix_row_sum_mean = (
-                coreset.kernel.calculate_kernel_matrix_row_sum_mean(original_array)
-            )
+        # If not already done on Coreset, calculate gramian_row_mean
+        gramian_row_mean = coreset.gramian_row_mean
+        if gramian_row_mean is None:
+            gramian_row_mean = coreset.kernel.gramian_row_mean(original_array)
 
         num_points_in_x = len(original_array)
 
@@ -562,7 +555,7 @@ class RefineReverse(Refine):
             self._refine_rev_body,
             x=original_array,
             kernel=coreset.kernel,
-            kernel_matrix_row_sum_mean=kernel_matrix_row_sum_mean,
+            gramian_row_mean=gramian_row_mean,
             kernel_gram_matrix_diagonal=kernel_gram_matrix_diagonal,
         )
         coreset_indices = lax.fori_loop(0, num_points_in_x, body, coreset_indices)
@@ -576,7 +569,7 @@ class RefineReverse(Refine):
         coreset_indices: ArrayLike,
         x: ArrayLike,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> Array:
         r"""
@@ -587,7 +580,7 @@ class RefineReverse(Refine):
         :param x: Original :math:`n \times d` dataset
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: Mean vector over rows for the Gram matrix,
+        :param gramian_row_mean: Mean vector over rows for the Gram matrix,
             a :math:`1 \times n` array
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -598,7 +591,7 @@ class RefineReverse(Refine):
             coreset_indices,
             x,
             kernel,
-            kernel_matrix_row_sum_mean,
+            gramian_row_mean,
             kernel_gram_matrix_diagonal,
         )
         coreset_indices = lax.cond(
@@ -619,7 +612,7 @@ class RefineReverse(Refine):
         coreset_indices: ArrayLike,
         x: ArrayLike,
         kernel: coreax.kernel.Kernel,
-        kernel_matrix_row_sum_mean: ArrayLike,
+        gramian_row_mean: ArrayLike,
         kernel_gram_matrix_diagonal: ArrayLike,
     ) -> Array:
         r"""
@@ -633,7 +626,7 @@ class RefineReverse(Refine):
         :param x: :math:`n \times d` original data
         :param kernel: Kernel used for calculating the maximum
             mean discrepancy, for comparing candidate coresets during refinement
-        :param kernel_matrix_row_sum_mean: :math:`1 \times n` row mean of the
+        :param gramian_row_mean: :math:`1 \times n` row mean of the
             :math:`n \times n` kernel matrix
         :param kernel_gram_matrix_diagonal: Gram matrix diagonal,
             a :math:`1 \times n` array
@@ -641,7 +634,7 @@ class RefineReverse(Refine):
         """
         coreset_indices = jnp.asarray(coreset_indices)
         x = jnp.asarray(x)
-        kernel_matrix_row_sum_mean = jnp.asarray(kernel_matrix_row_sum_mean)
+        gramian_row_mean = jnp.asarray(gramian_row_mean)
         kernel_gram_matrix_diagonal = jnp.asarray(kernel_gram_matrix_diagonal)
         num_points_in_coreset = len(coreset_indices)
 
@@ -651,7 +644,7 @@ class RefineReverse(Refine):
             + kernel.compute(x[coreset_indices], x[i])[:, 0]
             - kernel_gram_matrix_diagonal[coreset_indices]
         ) / (num_points_in_coreset**2) - (
-            kernel_matrix_row_sum_mean[coreset_indices] - kernel_matrix_row_sum_mean[i]
+            gramian_row_mean[coreset_indices] - gramian_row_mean[i]
         ) / num_points_in_coreset
 
     @jit

--- a/coreax/score_matching.py
+++ b/coreax/score_matching.py
@@ -592,7 +592,7 @@ class KernelDensityMatching(ScoreMatching):
             original_number_of_dimensions = x_.ndim
             x_ = jnp.atleast_2d(x_)
 
-            # Get the gram matrix row means
+            # Get the gram matrix row-mean
             gram_matrix_row_means = self.kernel.compute(x_, self.kde_data).mean(axis=1)
 
             # Compute gradients with respect to x

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -168,7 +168,6 @@ except TypeError:
 
 
 autodoc_custom_types: dict[Any, str] = {  # Specify custom types for autodoc_type_hints
-    coreax.util.KernelComputeType: ":obj:`~coreax.util.KernelComputeType`",  # no expand
     ArrayLike: ":data:`~jax.typing.ArrayLike`",
     OptionalArrayLike: ":data:`~jax.typing.ArrayLike` | :data:`None`",
 }

--- a/examples/herding_approximate_gram_matrix.py
+++ b/examples/herding_approximate_gram_matrix.py
@@ -19,10 +19,9 @@ This example showcases how a coreset can be generated from a dataset containing 
 points sampled from ``k`` clusters in space.
 
 A coreset is generated using kernel herding, with a Squared Exponential kernel. To
-reduce computational demand, we approximate the kernel matrix row sum mean (also known
-as the mean of the Gram matrix row sum). This coreset is compared to a coreset generated
-via uniform random sampling. Coreset quality is measured using maximum mean discrepancy
-(MMD).
+reduce computational demand, we approximate the kernel's Gramian row mean. This coreset
+is compared to a coreset generated via uniform random sampling. Coreset quality is
+measured using maximum mean discrepancy (MMD).
 """
 
 # Support annotations with | in Python < 3.10
@@ -54,13 +53,13 @@ from coreax.kernel import median_heuristic
 # pylint: disable=too-many-locals
 def main(out_path: Path | None = None) -> tuple[float, float]:
     """
-    Run the tabular data herding example with an approximate kernel matrix row sum mean.
+    Run the tabular data herding example with an approximate kernel Gramian row-mean.
 
     Generate a set of points from distinct clusters in a plane. Generate a coreset via
-    kernel herding, where computation time is reduced by approximating the kernel matrix
-    row sum mean, rather than computing it exactly with all data-points. Compare results
-    to coresets generated via uniform random sampling. Coreset quality is measured using
-    maximum mean discrepancy (MMD).
+    kernel herding, where computation time is reduced by approximating the kernel's
+    Gramian row-mean, rather than computing it exactly with all data-points. Compare
+    results to coresets generated via uniform random sampling. Coreset quality is
+    measured using maximum mean discrepancy (MMD).
 
     :param out_path: Path to save output to, if not :data:`None`, assumed relative to
         this module file unless an absolute path is given

--- a/examples/herding_approximate_gram_matrix.py
+++ b/examples/herding_approximate_gram_matrix.py
@@ -19,7 +19,7 @@ This example showcases how a coreset can be generated from a dataset containing 
 points sampled from ``k`` clusters in space.
 
 A coreset is generated using kernel herding, with a Squared Exponential kernel. To
-reduce computational demand, we approximate the kernel's Gramian row mean. This coreset
+reduce computational demand, we approximate the kernel's Gramian row-mean. This coreset
 is compared to a coreset generated via uniform random sampling. Coreset quality is
 measured using maximum mean discrepancy (MMD).
 """

--- a/tests/integration/test_herding_with_approximate_gram_matrix.py
+++ b/tests/integration/test_herding_with_approximate_gram_matrix.py
@@ -15,7 +15,7 @@
 """
 Integration test for basic herding example.
 
-This test uses an approximation to the kernel matrix row sum mean rather than an exact
+This test uses an approximation to the kernel's Gramian row-mean rather than an exact
 computation.
 """
 

--- a/tests/performance/test_coresubset.py
+++ b/tests/performance/test_coresubset.py
@@ -80,7 +80,7 @@ class TestCoreSubset(unittest.TestCase):
         post = []
         for i in range(self.num_samples_to_generate):
             # pylint: disable=protected-access
-            kernel_matrix_rsm = kernel.calculate_kernel_matrix_row_sum_mean(x[i])
+            kernel_matrix_rsm = kernel.gramian_row_mean(x[i])
             deltas = coreax.util.jit_test(
                 herding_object._greedy_body,
                 fn_kwargs={
@@ -88,7 +88,7 @@ class TestCoreSubset(unittest.TestCase):
                     "val": (coreset_indices_0, kernel_similarity_penalty_0),
                     "x": x[i],
                     "kernel_vectorised": kernel.compute,
-                    "kernel_matrix_row_sum_mean": kernel_matrix_rsm,
+                    "gramian_row_mean": kernel_matrix_rsm,
                     "unique": True,
                 },
                 jit_kwargs={"static_argnames": ["kernel_vectorised", "unique"]},

--- a/tests/unit/test_approximation.py
+++ b/tests/unit/test_approximation.py
@@ -153,7 +153,7 @@ class TestRandomRegressionApproximations:
         approximator_full = approximator(kernel, random_key, **full_kwargs)
         approximator_partial = approximator(kernel, random_key, **partial_kwargs)
 
-        # Approximate the kernel row mean using the full training set (so the
+        # Approximate the kernel row-mean using the full training set (so the
         # approximation should be very close to the true) and only part of the data for
         # training (so the error should grow)
         approximate_kernel_mean_full = approximator_full.gramian_row_mean(data)

--- a/tests/unit/test_approximation.py
+++ b/tests/unit/test_approximation.py
@@ -76,8 +76,8 @@ class TestRandomRegressionApproximations:
         For simplicity, we set ``length_scale`` to :math:`1.0/np.sqrt(2)`
         and ``output_scale`` to 1.0.
 
-        The tests here ensure that approximations to the kernel matrix row sum mean are
-        valid. For a single row (data record), kernel matrix row sum mean is computed by
+        The tests here ensure that approximations to the kernel's Gramian row-mean are
+        valid. For a single row (data record), kernel's Gramian row-mean is computed by
         applying the kernel to this data record and all other data records. We then sum
         the results and divide by the number of data records. The first
         data-record ``[0, 0]`` in the data considered here therefore gives a result of:
@@ -156,12 +156,8 @@ class TestRandomRegressionApproximations:
         # Approximate the kernel row mean using the full training set (so the
         # approximation should be very close to the true) and only part of the data for
         # training (so the error should grow)
-        approximate_kernel_mean_full = (
-            approximator_full.calculate_kernel_matrix_row_sum_mean(data)
-        )
-        approximate_kernel_mean_partial = (
-            approximator_partial.calculate_kernel_matrix_row_sum_mean(data)
-        )
+        approximate_kernel_mean_full = approximator_full.gramian_row_mean(data)
+        approximate_kernel_mean_partial = approximator_partial.gramian_row_mean(data)
 
         # Check the approximation is close to the true value
         np.testing.assert_array_almost_equal(
@@ -209,12 +205,8 @@ class TestRandomRegressionApproximations:
                 num_kernel_points=jnp.shape(data)[0],
                 num_train_points=jnp.shape(data)[0],
             )
-            result_exactly_num_data = (
-                approximator_exact_num_data.calculate_kernel_matrix_row_sum_mean(data)
-            )
-            result_more_than_num_data = (
-                test_approximator.calculate_kernel_matrix_row_sum_mean(data)
-            )
+            result_exactly_num_data = approximator_exact_num_data.gramian_row_mean(data)
+            result_more_than_num_data = test_approximator.gramian_row_mean(data)
             # Check the output is very close if we use all the data provided, or ask for
             # more than the number of points we have
             exact_delta = true_distances - result_exactly_num_data
@@ -230,7 +222,7 @@ class TestRandomRegressionApproximations:
             )
             with pytest.raises(ValueError, match=expected_msg):
                 test_approximator = approximator(kernel, random_key, **kwargs)
-                test_approximator.calculate_kernel_matrix_row_sum_mean(data)
+                test_approximator.gramian_row_mean(data)
 
     @pytest.mark.parametrize("num_train_points_multiplier", [-1, 0, 100])
     def test_degenerate_num_train_points(
@@ -259,7 +251,7 @@ class TestRandomRegressionApproximations:
             )
             with pytest.raises(ValueError, match=expected_msg):
                 test_approximator = approximator(kernel, random_key, **kwargs)
-                test_approximator.calculate_kernel_matrix_row_sum_mean(data)
+                test_approximator.gramian_row_mean(data)
 
     def test_invalid_kernel(
         self, problem: _Problem, approximator: type[RandomRegressionKernel]

--- a/tests/unit/test_coresubset.py
+++ b/tests/unit/test_coresubset.py
@@ -388,7 +388,7 @@ class TestKernelHerding(unittest.TestCase):
             # with index 2. Recall that gramian_row_mean is [0.6, 0.75, 0.55],
             # and so just from density alone, the next largest point in this is index 0.
             # However, the penalty term now makes the point with index 2 the highest
-            # overall when the kernel row mean and penalties are combined. Note the
+            # overall when the kernel row-mean and penalties are combined. Note the
             # 2.0* here because we divide the penalty term by loop index + 1
             kernel_similarity_penalty_1 = kernel_similarity_penalty_1.at[0].set(
                 2.0 * 0.59
@@ -644,7 +644,7 @@ class TestRandomSample(unittest.TestCase):
         ``n``: Number of test data points
         ``d``: Dimension of data
         ``m``: Number of points to randomly select for second dataset Y
-        ``max_size``: Maximum number of points for block calculations
+        ``block_size``: Maximum number of points for block calculations
         """
         # Define data parameters
         self.num_points_in_data = 30

--- a/tests/unit/test_reduction.py
+++ b/tests/unit/test_reduction.py
@@ -73,7 +73,7 @@ class TestCoreset(unittest.TestCase):
         original_data = MagicMock()
         coreset = MagicMock()
         coreset_indices = MagicMock()
-        kernel_matrix_row_sum_mean = MagicMock()
+        gramian_row_mean = MagicMock()
         original = CoresetMock(
             weights_optimiser=weights_optimiser,
             kernel=kernel,
@@ -82,7 +82,7 @@ class TestCoreset(unittest.TestCase):
         original.original_data = original_data
         original.coreset = coreset
         original.coreset_indices = coreset_indices
-        original.kernel_matrix_row_sum_mean = kernel_matrix_row_sum_mean
+        original.gramian_row_mean = gramian_row_mean
 
         # Create copy
         duplicate = original.clone_empty()
@@ -100,8 +100,8 @@ class TestCoreset(unittest.TestCase):
         self.assertIsNone(duplicate.coreset)
         self.assertIs(original.coreset_indices, coreset_indices)
         self.assertIsNone(duplicate.coreset_indices)
-        self.assertIs(original.kernel_matrix_row_sum_mean, kernel_matrix_row_sum_mean)
-        self.assertIsNone(duplicate.kernel_matrix_row_sum_mean)
+        self.assertIs(original.gramian_row_mean, gramian_row_mean)
+        self.assertIsNone(duplicate.gramian_row_mean)
 
     def test_fit(self):
         """Test that original data is saved and reduction strategy called."""

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -138,12 +138,12 @@ class RefineTestCase(ABC):
         ],
         ids=["no_unique_best", "unique_best"],
     )
-    @pytest.mark.parametrize("use_cached_row_sum_mean", [False, True])
+    @pytest.mark.parametrize("use_cached_row_mean", [False, True])
     def test_refine(
         self,
         refine_method: coreax.refine.Refine,
         problem: _RefineProblem,
-        use_cached_row_sum_mean: bool,
+        use_cached_row_mean: bool,
     ):
         """
         Test behaviour of the ``refine`` method when passed valid arguments.
@@ -157,8 +157,8 @@ class RefineTestCase(ABC):
         - The ``unique_best`` case tests scenarios with a unique "best" solution. This
         unique solution is expected even for random/greedy refinement methods.
 
-        When ``use_cached_row_sum_mean=True``, we expect the corresponding cached value
-        in the coreset object to be used by refine, otherwise, we expect the kernel's
+        When ``use_cached_row_mean=True``, we expect the corresponding cached value in
+        the coreset object to be used by refine, otherwise, we expect the kernel's
         gramian_row_mean to be called (exactly once).
         """
         array, test_indices, best_indices = problem
@@ -173,7 +173,7 @@ class RefineTestCase(ABC):
             coreset_obj.original_data = coreax.data.ArrayData.load(array)
             coreset_obj.coreset = array[coreset_indices, :]
 
-            if use_cached_row_sum_mean:
+            if use_cached_row_mean:
                 refine_method.refine(coreset=coreset_obj)
             else:
                 # If we aren't using the cached gramian_row_mean, then

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -130,12 +130,12 @@ class TestUtil:
         with pytest.raises(TypeError, match="not a valid JAX array type"):
             solve_qp(
                 kernel_mm="invalid_kernel_mm",
-                kernel_matrix_row_sum_mean=np.array([1, 2, 3]),
+                gramian_row_mean=np.array([1, 2, 3]),
             )
 
-    def test_solve_qp_invalid_kernel_matrix_row_sum_mean(self) -> None:
+    def test_solve_qp_invalid_gramian_row_mean(self) -> None:
         """
-        Test how solve_qp handles invalid inputs of kernel_matrix_row_sum_mean.
+        Test how solve_qp handles invalid inputs of gramian_row_mean.
 
         The output of solve_qp is indirectly tested when testing the various weight
         optimisers that are used in this codebase. This test just ensures sensible
@@ -146,7 +146,7 @@ class TestUtil:
         with pytest.raises(TypeError, match="not a valid JAX array type"):
             solve_qp(
                 kernel_mm=np.array([1, 2, 3]),
-                kernel_matrix_row_sum_mean="invalid_kernel_matrix_row_sum_mean",
+                gramian_row_mean="invalid_gramian_row_mean",
             )
 
     @pytest.mark.flaky(reruns=3)


### PR DESCRIPTION
### PR Type
Closes #599

- Bugfix
- Feature
- Code style update (formatting, local variables)
- Refactoring (no functional changes)
- Documentation content changes
- Tests

Renames the `kernel_matrix_row_sum_mean` to the more concise Gramian row-mean, and utilises `jax.lax.scan` to provide more control over the block iterated computation of this quantity.

More comprehensive testing is now performed when checking the behaviour of various `block_size` (previously called `max_size`) values, when passed to `gramian_row_mean`. As a result, some other tests have become redundant, and have been removed (primarily in `test_coresubset.py`).

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

(Write your answer here.)

### How Has This Been Tested?
All tests pass

### Does this PR introduce a breaking change?
removed `{update,calculate}_kernel_matrix_row_sum` and `calculate_kernel_matrix_row_sum_mean`; replaced by calls to `gramian_row_mean`. All references to `kernel_matrix_row_sum_mean` have been replaced by `gramian_row_mean`. The `KernelComputeType` has also been removed as it is now only used in `coresubset.py`.


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
