### PR TITLE
feat: add coreset and coresubset data structures

### DIFF
--- a/.cspell/custom_misc.txt
+++ b/.cspell/custom_misc.txt
@@ -29,4 +29,6 @@ regulariser
 RKHS
 RPCHOLESKY
 sigmas
-WMMd
+supp
+TLDR
+WMMD

--- a/.pylintrc
+++ b/.pylintrc
@@ -312,7 +312,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=1
+min-public-methods=0
 
 
 [EXCEPTIONS]

--- a/coreax/__init__.py
+++ b/coreax/__init__.py
@@ -58,6 +58,7 @@ from coreax.approximation import (
     MonteCarloApproximateKernel,
     NystromApproximateKernel,
 )
+from coreax.coreset import Coreset, Coresubset
 from coreax.coresubset import KernelHerding, RandomSample, RPCholesky, SteinThinning
 from coreax.data import ArrayData, Data, SupervisedData
 from coreax.kernel import (

--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Generic, TypeVar
+
 import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Shaped
 
 from coreax.data import Data
+
+_Data = TypeVar("_Data", bound=Data)
 
 
 def _convert_to_weighted(data: Data | Array):
@@ -15,7 +19,7 @@ def _convert_to_weighted(data: Data | Array):
     return Data(data)
 
 
-class Coreset(eqx.Module):
+class Coreset(eqx.Module, Generic[_Data]):
     r"""
     Data structure for representing a coreset.
 
@@ -58,7 +62,7 @@ class Coreset(eqx.Module):
     """
 
     nodes: Data = eqx.field(converter=_convert_to_weighted)
-    pre_coreset_data: Data
+    pre_coreset_data: _Data
 
     def __len__(self):
         """Return Coreset size/length."""
@@ -70,7 +74,7 @@ class Coreset(eqx.Module):
         return self.nodes
 
 
-class Coresubset(Coreset):
+class Coresubset(Coreset[_Data], Generic[_Data]):
     r"""
     Data structure for representing a coresubset.
 

--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -1,0 +1,114 @@
+"""Module for defining coreset data structures."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Shaped
+
+from coreax.data import Data
+
+
+def _convert_to_weighted(data: Data | Array):
+    if isinstance(data, Data):
+        return data
+    return Data(data)
+
+
+class Coreset(eqx.Module):
+    r"""
+    Data structure for representing a coreset.
+
+    TLDR: a coreset is a reduced set of :math:`\hat{n}` (potentially weighted) data
+    points that, in some sense, best represent the "important" properties of a larger
+    set of :math:`n > \hat{n}` (potentially weighted) data points.
+
+    Given a dataset :math:`X = \{x_i\}_{i=1}^n, x \in \Omega`, where each node is paired
+    with a non-negative (probability) weight :math:`w_i \in \mathbb{R} \ge 0`, there
+    exists an implied discrete (probability) measure over :math:`\Omega`
+
+    .. math:
+        \eta_n = \sum_{i=1}^{n} w_i \delta_{x_i}.
+
+    If we then specify a set of test-functions :math:`\Phi = {\phi_1, \dots, \phi_M}`,
+    where :math:`\phi_i \colon \Omega \to \mathbb{R}`, which somehow capture the
+    "important" properties of the data, then there also exists an implied push-forward
+    measure over :math:`\mathbb{R}^M`
+
+    .. math:
+        \mu_n = \sum_{i=1}^{n} w_i \delta_{\Phi(x_i)}.
+
+    A coreset is simply a reduced measure containing :math:`\hat{n} < n` updated nodes
+    :math:`\hat{x}_i` and weights :math:`\hat{w}_i`, such that the push-forward measure
+    of the coreset :math:`\nu_\hat{n}` has (approximately for some algorithms) the same
+    "centre-of-mass" as the push-forward measure for the original data :math:`\mu_n`
+
+    .. math:
+        \text{CoM}(\mu_n) = \text{CoM}(\nu_\hat{n}),
+        \text{CoM}(\nu_\hat{n}) = \int_\Omega \Phi(\omega) d\nu_\hat{x}(\omega),
+        \text{CoM}(\nu_\hat{n}) = \sum_{i=1}^\hat{n} \hat{w}_i \delta_{\Phi(\hat{x}_i)}.
+
+    .. note:
+        Depending on the algorithm, the test-functions may be explicitly specified by
+        the user, or implicitly defined by the algorithm's specific objectives.
+
+    :param nodes: The (weighted) coreset nodes, math:`x_i \in \text{supp}(\nu_\hat{n})`;
+        once instantiated, the nodes should be accessed via :meth:`Coresubset.coreset`
+    :param pre_coreset_data: The dataset :math:`X` used to construct the coreset.
+    """
+
+    nodes: Data = eqx.field(converter=_convert_to_weighted)
+    pre_coreset_data: Data
+
+    def __len__(self):
+        """Return Coreset size/length."""
+        return len(self.nodes)
+
+    @property
+    def coreset(self) -> Data:
+        """Materialised coreset."""
+        return self.nodes
+
+
+class Coresubset(Coreset):
+    r"""
+    Data structure for representing a coresubset.
+
+    A coresubset is a :class`Coreset`, with the additional condition that the support of
+    the reduced measure (the coreset), must be a subset of the support of the original
+    measure (the original data), such that
+
+    .. math:
+        \hat{x}_i = x_i, \forall i \in I,
+        I \subset \{1, \dots, n\}, text{card}(I) = \hat{n}.
+
+    Thus, a coresubset, unlike a corset, ensures that feasibility constraints on the
+    support of the measure are maintained :cite:`litterer2012recombination`. This is
+    vital if, for example, the test-functions are only defined on the support of the
+    original measure/nodes, rather than all of :math:`\Omega`.
+
+    In coresubsets, the measure reduction can be implicit (setting weights/nodes to
+    zero for all :math:`i \in I \ {1, \dots, n}`) or explicit (removing entries from the
+    weight/node arrays). The implicit approach is useful when input/output array shape
+    stability is required (E.G. for some JAX transformations); the explicit approach is
+    more similar to a standard coreset.
+
+    :param nodes: The (weighted) coresubset node indices, :math:`I`; the materialised
+        coresubset nodes should be accessed via :meth:`Coresubset.coreset`.
+    :param pre_coreset_data: The dataset :math:`X` used to construct the coreset.
+    """
+
+    # Incompatibility between Pylint and eqx.field. Pyright handles this correctly.
+    # pylint: disable=no-member
+    @property
+    def coreset(self) -> Data:
+        """Materialise the coresubset from the indices and original data."""
+        coreset_nodes = self.pre_coreset_data.data[self.unweighted_indices]
+        return Data(coreset_nodes, self.nodes.weights)
+
+    @property
+    def unweighted_indices(self) -> Shaped[Array, " n"]:
+        """Unweighted Coresubset indices - attribute access helper."""
+        return jnp.squeeze(self.nodes.data)
+
+    # pylint: enable=no-member

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -191,7 +191,6 @@ class ArrayData(DataReader):
         return coreset.coreset
 
 
-# pylint: disable=too-few-public-methods
 class Data(eqx.Module):
     r"""
     Class for representing unsupervised data.
@@ -207,8 +206,8 @@ class Data(eqx.Module):
         uniform weighting.
     """
 
-    data: Shaped[Array, " n d"]
-    weights: Shaped[Array, " n"]
+    data: Shaped[Array, " n d"] = eqx.field(converter=jnp.atleast_2d)
+    weights: Shaped[Array, " n"] = eqx.field(converter=jnp.atleast_1d)
 
     def __init__(
         self, data: Shaped[Array, " n d"], weights: Shaped[Array, " n"] | None = None
@@ -225,6 +224,10 @@ class Data(eqx.Module):
         """Check leading dimensions of weights and data match."""
         if self.weights.shape[0] != self.data.shape[0]:
             raise ValueError("Leading dimensions of 'weights' and 'data' must be equal")
+
+    def __len__(self):
+        """Return data length."""
+        return len(self.data)
 
 
 class SupervisedData(Data):
@@ -246,7 +249,7 @@ class SupervisedData(Data):
         :data:`None` will result in uniform weighting.
     """
 
-    supervision: Shaped[Array, " n *p"]
+    supervision: Shaped[Array, " n *p"] = eqx.field(converter=jnp.atleast_2d)
 
     def __init__(
         self,
@@ -264,6 +267,3 @@ class SupervisedData(Data):
             raise ValueError(
                 "Leading dimensions of 'supervision' and 'data' must be equal"
             )
-
-
-# pylint: enable=too-few-public-methods

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -199,11 +199,11 @@ class Data(eqx.Module):
     where :math`x_i` are the features or inputs and :math:`w_i` are weights.
 
     :param data: An :math:`n \times d` array defining the features of the unsupervised
-        dataset.
+        dataset; d-vectors are converted to :math:`1 \times d` arrays
     :param weights: An :math:`n`-vector of weights where each element of the weights
         vector is is paired with the corresponding index of the data array, forming the
         pair :math:`(x_i, w_i)`, or if not required, default :data:`None` will result in
-        uniform weighting.
+        uniform weighting
     """
 
     data: Shaped[Array, " n d"] = eqx.field(converter=jnp.atleast_2d)
@@ -240,13 +240,15 @@ class SupervisedData(Data):
     correspond to the pairs :math:`(x_i, y_i)`.
 
     :param data: An :math:`n \times d` array defining the features of the supervised
-        dataset paired with the corresponding index of the supervision.
+        dataset paired with the corresponding index of the supervision;  d-vectors are
+        converted to :math:`1 \times d` arrays
     :param supervision: An :math:`n \times p` array defining the responses of the
-        supervised paired with the corresponding index of the data.
+        supervised paired with the corresponding index of the data; d-vectors are
+        converted to :math:`1 \times d` arrays
     :param weights: An :math:`n`-vector of weights where each element of the weights
         vector is is paired with the corresponding index of the data and supervision
         array, forming the triple :math:`(x_i, y_i, w_i)`, or if not required, default
-        :data:`None` will result in uniform weighting.
+        :data:`None` will result in uniform weighting
     """
 
     supervision: Shaped[Array, " n *p"] = eqx.field(converter=jnp.atleast_2d)

--- a/tests/unit/test_coreset.py
+++ b/tests/unit/test_coreset.py
@@ -1,0 +1,52 @@
+"""Tests for coreset data-structures."""
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+from coreax.coreset import Coreset, Coresubset
+from coreax.data import Data
+
+NODES = Data(jnp.arange(5, dtype=jnp.int32)[..., None])
+PRE_CORESET_DATA = Data(jnp.arange(10)[..., None])
+
+
+@pytest.mark.parametrize("coreset_type", [Coreset, Coresubset])
+class TestCoresetCommon:
+    """Common tests for `coreax.coreset.Coreset` and `coreax.coreset.Coresubset`."""
+
+    def test_init_array_conversion(self, coreset_type):
+        """
+        Test the initialisation behaviour.
+
+        The nodes can be passed as an 'Array' or as a 'Data' instance. In the former
+        case, we expect this array to be automatically converted to a 'Data' instance.
+        """
+        array_nodes = NODES.data
+        coreset_array_nodes = coreset_type(array_nodes, PRE_CORESET_DATA)
+        coreset_data_nodes = coreset_type(NODES, PRE_CORESET_DATA)
+        assert coreset_array_nodes == coreset_data_nodes
+
+    def test_materialization(self, coreset_type):
+        """Test the coreset materialisation behaviour."""
+        coreset = coreset_type(NODES, PRE_CORESET_DATA)
+        expected_materialization = coreset.nodes
+        if isinstance(coreset, Coresubset):
+            materialized_nodes = PRE_CORESET_DATA.data[NODES.data.squeeze()]
+            expected_materialization = Data(materialized_nodes)
+        assert expected_materialization == coreset.coreset
+
+    def test_len(self, coreset_type):
+        """Test the coreset length."""
+        coreset = coreset_type(NODES, PRE_CORESET_DATA)
+        assert len(coreset) == len(NODES.data)
+
+
+class TestCoresubset:
+    """Tests specific to `coreax.coreset.Coresubset`."""
+
+    def test_unweighted_indices(self):
+        """Test the coresubset 'unweighted_indices' property."""
+        coresubset = Coresubset(NODES, PRE_CORESET_DATA)
+        expected_indices = NODES.data.squeeze()
+        assert eqx.tree_equal(expected_indices, coresubset.unweighted_indices)


### PR DESCRIPTION
### PR Type
Closes #518
- Feature
- Tests

### Description
As part of #581, it is necessary to decouple the coreset data-structures and solvers/reduction-strategies. The new `coreax.coreset.Coreset` and `coreax.coreset.Coresubset` data-structures introduced here facilitate this decoupling, such that the conceptual notion of a coreset better reflects our implementation. I.E. a coreset is a data-structure and a solver is a solver, the current implementation treats a coreset as both of these things.

Note: these new data-structures are currently unused. They will be used in an upcoming PR to fully address #581.

A new set of unit tests have been created for these new data-structures in `tests/unit/test_coreset.py`.

Additionally updates the new `coreax.data.Data` with `at_least{1,2}d` equinox converters and a `__len__` magic method. This facilitates the coreset `__len__` magic method, and will allow many `atleast_{1,2}d` calls to be removed from the codebase, at a later date.

Tests for `coreax.data.Data` have been refactored to reduce code duplication resulting from a new test for the new `__len__` method.

### How Has This Been Tested?
All tests pass

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
