### PR TITLE
Bugfix/kernel types

### DIFF
--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -314,9 +314,6 @@ class LinearKernel(Kernel):
     \to \mathbb{R}`, :math:`k(x, y) = x^Ty`.
     """
 
-    length_scale: float = 1.0
-    output_scale: float = 1.0
-
     @override
     def compute_elementwise(self, x: ArrayLike, y: ArrayLike) -> Array:
         return jnp.dot(x, y)
@@ -514,11 +511,9 @@ class SteinKernel(CompositeKernel):
         the Stein kernel
     :param score_function: A vector-valued callable defining a score function
         :math:`\mathbb{R}^d \to \mathbb{R}^d`
-    :param output_scale: Kernel normalisation constant
     """
 
     score_function: Callable[[ArrayLike], Array]
-    output_scale: float = 1.0
 
     @override
     def compute_elementwise(self, x: ArrayLike, y: ArrayLike) -> Array:

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -81,7 +81,7 @@ def apply_negative_precision_threshold(
 
 def pairwise(
     fn: Callable[[ArrayLike, ArrayLike], Array],
-) -> Callable[[Array, Array], Array]:
+) -> Callable[[ArrayLike, ArrayLike], Array]:
     """
     Transform a function so it returns all pairwise evaluations of its inputs.
 
@@ -91,7 +91,7 @@ def pairwise(
     """
 
     @wraps(fn)
-    def pairwise_fn(x: Array, y: Array) -> Array:
+    def pairwise_fn(x: ArrayLike, y: ArrayLike) -> Array:
         x = jnp.atleast_2d(x)
         y = jnp.atleast_2d(y)
         return vmap(

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -198,7 +198,8 @@ class TestLinearKernel(
     @pytest.fixture
     def kernel_factory(self) -> _KernelFactory[LinearKernel]:
         def kernel(length_scale, output_scale):
-            return LinearKernel(length_scale, output_scale)
+            del length_scale, output_scale
+            return LinearKernel()
 
         return kernel
 


### PR DESCRIPTION
### PR Type
- Bugfix
- Tests

### Description
Fixes some misc pyright complaints and removes redundant uses of `length_scale` and `output_scale`

### How Has This Been Tested?
All tests pass

### Does this PR introduce a breaking change?
- `LinearKernel` no longer has `{length,output}_scale` parameters
- `SteinKernel` no longer has an `output_scale` parameter

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
