### PR TITLE
Feature/kernel compute mean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
       - id: forbid-tabs
         exclude: documentation/make.bat|documentation/Makefile
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.8.0
+    rev: v8.8.1
     hooks:
       # Run a spellcheck (words pulled from cspell.config.yaml)
       - id: cspell

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -231,7 +231,7 @@ class Data(eqx.Module):
 
 
 def is_data(x: Any | Data):
-    """Return 'True' if element is and instance of 'coreax.data.Data'."""
+    """Return 'True' if element is an instance of 'coreax.data.Data'."""
     return isinstance(x, Data)
 
 

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -39,7 +39,7 @@ copy of a coreset, call :meth:`format() <DataReader.format>` on a subclass to re
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -201,33 +201,38 @@ class Data(eqx.Module):
     :param data: An :math:`n \times d` array defining the features of the unsupervised
         dataset; d-vectors are converted to :math:`1 \times d` arrays
     :param weights: An :math:`n`-vector of weights where each element of the weights
-        vector is is paired with the corresponding index of the data array, forming the
-        pair :math:`(x_i, w_i)`, or if not required, default :data:`None` will result in
-        uniform weighting
+        vector is paired with the corresponding index of the data array, forming the
+        pair :math:`(x_i, w_i)`; if passed a scalar weight, it will be broadcast to an
+        :math:`n`-vector. the default value of :data:`None` sets the weights to
+        the ones vector (implies a scalar weight of one);
     """
 
-    data: Shaped[Array, " n d"] = eqx.field(converter=jnp.atleast_2d)
-    weights: Shaped[Array, " n"] = eqx.field(converter=jnp.atleast_1d)
+    data: Shaped[Array, " n d"]
+    weights: Shaped[Array, " n"]
 
     def __init__(
-        self, data: Shaped[Array, " n d"], weights: Shaped[Array, " n"] | None = None
+        self,
+        data: Shaped[ArrayLike, " n d"],
+        weights: Shaped[ArrayLike, " n"] | None = None,
     ):
         """Initialise Data class."""
-        self.data = data
-        if weights is None:
-            n = data.shape[0]
-            self.weights = jnp.broadcast_to(1 / n, (n,))
-        else:
-            self.weights = weights
-
-    def __check_init__(self):
-        """Check leading dimensions of weights and data match."""
-        if self.weights.shape[0] != self.data.shape[0]:
-            raise ValueError("Leading dimensions of 'weights' and 'data' must be equal")
+        self.data = jnp.atleast_2d(data)
+        n = self.data.shape[0]
+        self.weights = jnp.broadcast_to(1 if weights is None else weights, n)
 
     def __len__(self):
         """Return data length."""
         return len(self.data)
+
+    def normalize(self) -> Data:
+        """Return a copy of 'self' with 'weights' that sum to one."""
+        normalized_weights = self.weights / jnp.sum(self.weights)
+        return eqx.tree_at(lambda x: x.weights, self, normalized_weights)
+
+
+def is_data(x: Any | Data):
+    """Return 'True' if element is and instance of 'coreax.data.Data'."""
+    return isinstance(x, Data)
 
 
 class SupervisedData(Data):
@@ -247,8 +252,9 @@ class SupervisedData(Data):
         converted to :math:`1 \times d` arrays
     :param weights: An :math:`n`-vector of weights where each element of the weights
         vector is is paired with the corresponding index of the data and supervision
-        array, forming the triple :math:`(x_i, y_i, w_i)`, or if not required, default
-        :data:`None` will result in uniform weighting
+        array, forming the triple :math:`(x_i, y_i, w_i)`; if passed a scalar weight,
+        it will be broadcast to an :math:`n`-vector. the default value of :data:`None`
+        sets the weights to the ones vector (implies a scalar weight of one);
     """
 
     supervision: Shaped[Array, " n *p"] = eqx.field(converter=jnp.atleast_2d)

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -362,7 +362,12 @@ def _block_data_convert(
         padding = (0, ceil(n / block_size) * block_size - n)
         skip_padding = ((0, 0),) * (jnp.ndim(x) - 1)
         x_padded = jnp.pad(x, (padding, *skip_padding))
-        return x_padded.reshape(-1, block_size, *remaining_shape)
+        try:
+            return x_padded.reshape(-1, block_size, *remaining_shape)
+        except ZeroDivisionError as err:
+            if 0 in x.shape:
+                raise ValueError("'x' must not be empty") from err
+            raise
 
     return jtu.tree_map(_pad_reshape, x, is_leaf=eqx.is_array_like), unpadded_length
 

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -290,7 +290,7 @@ class Kernel(eqx.Module):
 
         .. note:
             The data ``x`` and/or ``y`` are padded with zero-valued and zero-weighted
-            data points, when ``B_x`` and/or ``B_y``an non-integer divisors of ``n``
+            data points, when ``B_x`` and/or ``B_y`` are non-integer divisors of ``n``
             and/or ``m``. Padding does not alter the result, but does provide the block
             shape stability required by :func:`jax.lax.scan` (used for block iteration).
 

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -44,7 +44,6 @@ class NotCalculatedError(Exception):
     """Raise when trying to use a variable that has not been calculated yet."""
 
 
-# pylint: disable=too-few-public-methods
 class InvalidKernel:
     """
     Simple class that does not have a compute method on to test kernel.
@@ -56,9 +55,6 @@ class InvalidKernel:
     def __init__(self, x: float):
         """Initialise the invalid kernel object."""
         self.x = x
-
-
-# pylint: enable=too-few-public-methods
 
 
 def apply_negative_precision_threshold(

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -159,9 +159,11 @@ nitpick_ignore = [
     ("py:class", "flax.linen.module._Sentinel"),
     ("py:class", "jaxtyping.Shaped[Array, 'n *d']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n d']"),
+    ("py:class", "jaxtyping.Shaped[ndarray, 'n d']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n *p']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n p']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n']"),
+    ("py:class", "jaxtyping.Shaped[ndarray, 'n']"),
 ]
 
 # Quotes are required with UnionType for Python < 3.10

--- a/documentation/source/coreax/kernel.rst
+++ b/documentation/source/coreax/kernel.rst
@@ -3,3 +3,4 @@ Kernels
 
 .. automodule:: coreax.kernel
     :no-undoc-members:
+    :no-private-members:

--- a/examples/david_map_reduce_weighted.py
+++ b/examples/david_map_reduce_weighted.py
@@ -110,7 +110,7 @@ def main(
 
     # Path to original image
     original_data = cv2.imread(str(in_path))
-    image_data = cv2.cvtColor(original_data, cv2.COLOR_BGR2GRAY)
+    image_data = np.asarray(cv2.cvtColor(original_data, cv2.COLOR_BGR2GRAY))
     # Pool/downsample the image
     window_shape = (downsampling_factor, downsampling_factor)
     pooled_image_data = linen.avg_pool(
@@ -261,6 +261,7 @@ def main(
 # pylint: enable=too-many-locals
 # pylint: enable=too-many-statements
 # pylint: enable=duplicate-code
+
 
 if __name__ == "__main__":
     main()

--- a/examples/pounce.py
+++ b/examples/pounce.py
@@ -88,7 +88,8 @@ def main(
         out_path.mkdir(exist_ok=True)
 
     # Read in the data as a video. Frame 0 is missing A from RGBA.
-    raw_data = np.array(imageio.v2.mimread(in_path)[1:])
+    _, *image_data = imageio.v2.mimread(in_path)
+    raw_data = np.asarray(image_data)
     raw_data_reshaped = raw_data.reshape(raw_data.shape[0], -1)
 
     # Fix random behaviour

--- a/examples/pounce_map_reduce.py
+++ b/examples/pounce_map_reduce.py
@@ -97,7 +97,8 @@ def main(
         out_path.mkdir(exist_ok=True)
 
     # Read in the data as a video. Frame 0 is missing A from RGBA.
-    raw_data = np.array(imageio.v2.mimread(in_path)[1:])
+    _, *image_data = imageio.v2.mimread(in_path)
+    raw_data = np.asarray(image_data)
     raw_data_reshaped = raw_data.reshape(raw_data.shape[0], -1)
 
     # Fix random behaviour

--- a/examples/pounce_map_reduce_ssm.py
+++ b/examples/pounce_map_reduce_ssm.py
@@ -89,7 +89,8 @@ def main(
         out_path.mkdir(exist_ok=True)
 
     # Read in the data as a video. Frame 0 is missing A from RGBA.
-    raw_data = np.array(imageio.v2.mimread(in_path)[1:])
+    _, *image_data = imageio.v2.mimread(in_path)
+    raw_data = np.array(image_data)
     raw_data_reshaped = raw_data.reshape(raw_data.shape[0], -1)
 
     # Fix random behaviour

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -37,6 +37,12 @@ DATA_ARRAY = jnp.array([[1], [2], [3]])
 SUPERVISION = jnp.array([[4], [5], [6]])
 
 
+def test_is_data():
+    """Test functionality of `is_data` filter method."""
+    assert not coreax.data.is_data(123)
+    assert coreax.data.is_data(coreax.data.Data(1))
+
+
 @pytest.mark.parametrize(
     "data_type",
     [


### PR DESCRIPTION
### PR Type
Closes: #617

- Feature
- Tests

### Description
add `compute_mean` to `coreax.kernel.Kernel`
    
The new `compute_mean` method generalizes the functionality of `gramian_row_mean`, allowing any kernel matrix mean to be computed block-wise. When data is weighted, the mean is computed in the same way as `jax.numpy.average`.

In the future, the `compute_mean` method should be used to remove what is now duplicated functionality from `coreax.metrics.MMD`.

Some additional adjustments were made to `Data` to facilitate these changes. See commit message for further information.

### How Has This Been Tested?
All tests pass locally

### Does this PR introduce a breaking change?
`Data.weights` default to an un-normalized vector of ones with length equal to `Data.data`; prior to this commit, the default weights were normalized.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
