### PR TITLE
Feature/refactor metrics

### DIFF
--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -31,7 +31,7 @@ class Coreset(eqx.Module, Generic[_Data]):
     with a non-negative (probability) weight :math:`w_i \in \mathbb{R} \ge 0`, there
     exists an implied discrete (probability) measure over :math:`\Omega`
 
-    .. math:
+    .. math::
         \eta_n = \sum_{i=1}^{n} w_i \delta_{x_i}.
 
     If we then specify a set of test-functions :math:`\Phi = {\phi_1, \dots, \phi_M}`,
@@ -39,7 +39,7 @@ class Coreset(eqx.Module, Generic[_Data]):
     "important" properties of the data, then there also exists an implied push-forward
     measure over :math:`\mathbb{R}^M`
 
-    .. math:
+    .. math::
         \mu_n = \sum_{i=1}^{n} w_i \delta_{\Phi(x_i)}.
 
     A coreset is simply a reduced measure containing :math:`\hat{n} < n` updated nodes
@@ -47,12 +47,12 @@ class Coreset(eqx.Module, Generic[_Data]):
     of the coreset :math:`\nu_\hat{n}` has (approximately for some algorithms) the same
     "centre-of-mass" as the push-forward measure for the original data :math:`\mu_n`
 
-    .. math:
+    .. math::
         \text{CoM}(\mu_n) = \text{CoM}(\nu_\hat{n}),
         \text{CoM}(\nu_\hat{n}) = \int_\Omega \Phi(\omega) d\nu_\hat{x}(\omega),
         \text{CoM}(\nu_\hat{n}) = \sum_{i=1}^\hat{n} \hat{w}_i \delta_{\Phi(\hat{x}_i)}.
 
-    .. note:
+    .. note::
         Depending on the algorithm, the test-functions may be explicitly specified by
         the user, or implicitly defined by the algorithm's specific objectives.
 

--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -82,7 +82,7 @@ class Coresubset(Coreset[_Data], Generic[_Data]):
     the reduced measure (the coreset), must be a subset of the support of the original
     measure (the original data), such that
 
-    .. math:
+    .. math::
         \hat{x}_i = x_i, \forall i \in I,
         I \subset \{1, \dots, n\}, text{card}(I) = \hat{n}.
 

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -247,7 +247,7 @@ class Kernel(eqx.Module):
         :param block_size: Size of matrix blocks to process; a value of :data:`None`
             sets :math:`B_x = n`, effectively disabling the block accumulation; an
             integer value ``B`` sets :math:`B_x = B`; to reduce overheads, it is often
-            sensible to select the largest block size which does not exhaust the
+            sensible to select the largest block size that does not exhaust the
             available memory resources
         :param unroll: Unrolling parameter for the outer and inner :func:`jax.lax.scan`
             calls, allows for trade-offs between compilation and runtime cost; consult
@@ -279,16 +279,16 @@ class Kernel(eqx.Module):
         If ``x`` and ``y`` are of type :class:`~coreax.data.Data`, their weights are
         used to compute the weighted mean as defined in :func:`jax.numpy.average`.
 
-        .. note:
-            Unlike the conventional 'mean', which is a scalar, the 'row-mean' is an
-            :math:`m`-vector, while the 'column-mean' is an :math:`n`-vector.
+        .. note::
+            The conventional 'mean' is a scalar, the 'row-mean' is an :math:`m`-vector,
+            while the 'column-mean' is an :math:`n`-vector.
 
-        To avoid materializing the entire matrix (memory cost :math:`\mathcal{O}(n m)),
+        To avoid materializing the entire matrix (memory cost :math:`\mathcal{O}(n m)`),
         we accumulate the mean over blocks (memory cost :math:`\mathcal{O}(B_x B_y)`,
         where ``B_x`` and ``B_y`` are user-specified block-sizes for blocking the ``x``
         and ``y`` parameters respectively.
 
-        .. note:
+        .. note::
             The data ``x`` and/or ``y`` are padded with zero-valued and zero-weighted
             data points, when ``B_x`` and/or ``B_y`` are non-integer divisors of ``n``
             and/or ``m``. Padding does not alter the result, but does provide the block
@@ -302,7 +302,7 @@ class Kernel(eqx.Module):
             sets :math:`B_x = n` and :math:`B_y = m`, effectively disabling the block
             accumulation; an integer value ``B`` sets :math:`B_y = B_x = B`; a tuple
             allows different sizes to be specified for ``B_x`` and ``B_y``; to reduce
-            overheads, it is often sensible to select the largest block size which does
+            overheads, it is often sensible to select the largest block size that does
             not exhaust the available memory resources
         :param unroll: Unrolling parameter for the outer and inner :func:`jax.lax.scan`
             calls, allows for trade-offs between compilation and runtime cost; consult

--- a/coreax/metrics.py
+++ b/coreax/metrics.py
@@ -60,14 +60,14 @@ class MMD(Metric[_Data]):
     r"""
     Definition and calculation of the (weighted) maximum mean discrepancy metric.
 
-    For a dataset :math:`\mathcal_{D}_1` of ``n`` points in ``d`` dimensions, and
-    another dataset :math:`\mathcal_{D}_2` of ``m`` points in ``d`` dimensions, the
+    For a dataset :math:`\mathcal{D}_1` of ``n`` points in ``d`` dimensions, and
+    another dataset :math:`\mathcal{D}_2` of ``m`` points in ``d`` dimensions, the
     (weighted) maximum mean discrepancy is given by:
 
     .. math:
-        \text{MMD}^2(\mathcal_{D}_1,\mathcal_{D}_2) = \mathbb{E}(k(\mathcal_{D}_1,
-        \mathcal_{D}_1)) + \mathbb{E}(k(\mathcal_{D}_2,\mathcal_{D}_2))
-        - 2\mathbb{E}(k(\mathcal_{D}_1,\mathcal_{D}_2))
+        \text{MMD}^2(\mathcal{D}_1,\mathcal{D}_2) = \mathbb{E}(k(\mathcal{D}_1,
+        \mathcal{D}_1)) + \mathbb{E}(k(\mathcal{D}_2,\mathcal{D}_2))
+        - 2\mathbb{E}(k(\mathcal{D}_1,\mathcal{D}_2))
 
     where :math:`k` is the selected kernel, and the expectation is with respect to the
     normalized data weights.
@@ -98,9 +98,9 @@ class MMD(Metric[_Data]):
         Compute the (weighted) maximum mean discrepancy.
 
         .. math:
-            \text{MMD}^2(\mathcal_{D}_1,\mathcal_{D}_2) = \mathbb{E}(k(\mathcal_{D}_1,
-            \mathcal_{D}_1)) + \mathbb{E}(k(\mathcal_{D}_2,\mathcal_{D}_2))
-            - 2\mathbb{E}(k(\mathcal_{D}_1,\mathcal_{D}_2))
+            \text{MMD}^2(\mathcal{D}_1,\mathcal{D}_2) = \mathbb{E}(k(\mathcal{D}_1,
+            \mathcal{D}_1)) + \mathbb{E}(k(\mathcal{D}_2,\mathcal{D}_2))
+            - 2\mathbb{E}(k(\mathcal{D}_1,\mathcal{D}_2))
 
         :param reference_data: An instance of the class :class:`coreax.data.Data`,
             containing an :math:`n \times d` array of data

--- a/coreax/metrics.py
+++ b/coreax/metrics.py
@@ -64,7 +64,7 @@ class MMD(Metric[_Data]):
     another dataset :math:`\mathcal{D}_2` of ``m`` points in ``d`` dimensions, the
     (weighted) maximum mean discrepancy is given by:
 
-    .. math:
+    .. math::
         \text{MMD}^2(\mathcal{D}_1,\mathcal{D}_2) = \mathbb{E}(k(\mathcal{D}_1,
         \mathcal{D}_1)) + \mathbb{E}(k(\mathcal{D}_2,\mathcal{D}_2))
         - 2\mathbb{E}(k(\mathcal{D}_1,\mathcal{D}_2))
@@ -97,7 +97,7 @@ class MMD(Metric[_Data]):
         r"""
         Compute the (weighted) maximum mean discrepancy.
 
-        .. math:
+        .. math::
             \text{MMD}^2(\mathcal{D}_1,\mathcal{D}_2) = \mathbb{E}(k(\mathcal{D}_1,
             \mathcal{D}_1)) + \mathbb{E}(k(\mathcal{D}_2,\mathcal{D}_2))
             - 2\mathbb{E}(k(\mathcal{D}_1,\mathcal{D}_2))
@@ -111,7 +111,7 @@ class MMD(Metric[_Data]):
             sets :math:`B_x = n` and :math:`B_y = m`, effectively disabling the block
             accumulation; an integer value ``B`` sets :math:`B_y = B_x = B`; a tuple
             allows different sizes to be specified for ``B_x`` and ``B_y``; to reduce
-            overheads, it is often sensible to select the largest block size which does
+            overheads, it is often sensible to select the largest block size that does
             not exhaust the available memory resources
         :param unroll: Unrolling parameter for the outer and inner :func:`jax.lax.scan`
             calls, allows for trade-offs between compilation and runtime cost; consult

--- a/coreax/metrics.py
+++ b/coreax/metrics.py
@@ -25,12 +25,12 @@ module, all of which implement :class:`Metric`.
 # Support annotations with | in Python < 3.10
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Generic, TypeVar
 
+import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
-from jax.typing import ArrayLike
 
 import coreax.data
 import coreax.kernel
@@ -39,48 +39,38 @@ import coreax.util
 _Data = TypeVar("_Data", bound=coreax.data.Data)
 
 
-class Metric(ABC, Generic[_Data]):
+class Metric(eqx.Module, Generic[_Data]):
     """Base class for calculating metrics."""
 
     @abstractmethod
-    def compute(
-        self,
-        reference_data: _Data,
-        comparison_data: _Data,
-    ) -> Array:
+    def compute(self, reference_data: _Data, comparison_data: _Data, **kwargs) -> Array:
         r"""
-        Compute the metric.
-
-        Return a zero-dimensional array.
+        Compute the metric/distance between the reference and comparison data.
 
         :param reference_data: An instance of the class :class:`coreax.data.Data`,
-            containing an :math:`n \times d` array of data. Or an instance of the class
-            :class:`coreax.data.SupervisedData` containing an :math:`n \times d` array
-            of data, and a corresponding :math:`n \times p` array of supervision.
+            containing an :math:`n \times d` array of data
         :param comparison_data: An instance of the class :class:`coreax.data.Data` to
-            compare against ``reference_data`` containing an :math:`m \times d` array of
-            data. Or an instance of the class :class:`coreax.data.SupervisedData` to
-            compare against ``reference_data`` containing an :math:`m \times d` array of
-            data, and a corresponding :math:`m \times p` array of supervision.
-        :return: Metric computed as a zero-dimensional array
+            compare against ``reference_data``, containing an :math:`m \times d` array
+            of data
+        :return: Computed metric as a zero-dimensional array
         """
 
 
-class MMD(Metric, Generic[_Data]):
+class MMD(Metric[_Data]):
     r"""
-    Definition and calculation of the maximum mean discrepancy metric.
+    Definition and calculation of the (weighted) maximum mean discrepancy metric.
 
-    For a dataset of ``n`` points in ``d`` dimensions, :math:`\mathcal_{D}_1`, and
+    For a dataset :math:`\mathcal_{D}_1` of ``n`` points in ``d`` dimensions, and
     another dataset :math:`\mathcal_{D}_2` of ``m`` points in ``d`` dimensions, the
-    maximum mean discrepancy is given by:
+    (weighted) maximum mean discrepancy is given by:
 
-    .. math::
-
+    .. math:
         \text{MMD}^2(\mathcal_{D}_1,\mathcal_{D}_2) = \mathbb{E}(k(\mathcal_{D}_1,
         \mathcal_{D}_1)) + \mathbb{E}(k(\mathcal_{D}_2,\mathcal_{D}_2))
         - 2\mathbb{E}(k(\mathcal_{D}_1,\mathcal_{D}_2))
 
-    where :math:`k` is the selected kernel.
+    where :math:`k` is the selected kernel, and the expectation is with respect to the
+    normalized data weights.
 
     Common uses of MMD include comparing a reduced representation of a dataset to the
     original dataset, comparing different original datasets to one another, or
@@ -88,423 +78,54 @@ class MMD(Metric, Generic[_Data]):
 
     :param kernel: Kernel object with compute method defined mapping
         :math:`k: \mathbb{R}^d \times \mathbb{R}^d \rightarrow \mathbb{R}`
-    :param precision_threshold: Positive threshold we compare against for precision
+    :param precision_threshold: Threshold above which negative values of the squared MMD
+        are rounded to zero (accommodates precision loss)
     """
 
-    def __init__(self, kernel: coreax.kernel.Kernel, precision_threshold: float = 1e-8):
-        """Calculate maximum mean discrepancy between two datasets."""
-        self.kernel = kernel
-        self.precision_threshold = precision_threshold
-
-        # Initialise parent
-        super().__init__()
+    kernel: coreax.kernel.Kernel
+    precision_threshold: float = 1e-12
 
     def compute(
         self,
         reference_data: _Data,
         comparison_data: _Data,
-        block_size: int | None = None,
+        *,
+        block_size: int | None | tuple[int | None, int | None] = None,
+        unroll: tuple[int | bool, int | bool] = (1, 1),
+        **kwargs,
     ) -> Array:
         r"""
-        Calculate maximum mean discrepancy.
+        Compute the (weighted) maximum mean discrepancy.
 
-        If uniform weights are given for datasets ``reference_data`` and
-        ``comparison_data`` standard MMD is calculated. If non-uniform weights are
-        given, weighted MMD is calculated. For both cases, if the size of matrix blocks
-        to process is less than the size of both datasets, and the reference and
-        comparison weights are not uniform in the weighted case, the calculation is done
-        block-wise to limit memory requirements.
+        .. math:
+            \text{MMD}^2(\mathcal_{D}_1,\mathcal_{D}_2) = \mathbb{E}(k(\mathcal_{D}_1,
+            \mathcal_{D}_1)) + \mathbb{E}(k(\mathcal_{D}_2,\mathcal_{D}_2))
+            - 2\mathbb{E}(k(\mathcal_{D}_1,\mathcal_{D}_2))
 
         :param reference_data: An instance of the class :class:`coreax.data.Data`,
             containing an :math:`n \times d` array of data
         :param comparison_data: An instance of the class :class:`coreax.data.Data` to
             compare against ``reference_data`` containing an :math:`m \times d` array of
             data
-        :param block_size: Size of matrix block to process, or :data:`None` to not split
-            into blocks
+        :param block_size: Size of matrix blocks to process; a value of :data:`None`
+            sets :math:`B_x = n` and :math:`B_y = m`, effectively disabling the block
+            accumulation; an integer value ``B`` sets :math:`B_y = B_x = B`; a tuple
+            allows different sizes to be specified for ``B_x`` and ``B_y``; to reduce
+            overheads, it is often sensible to select the largest block size which does
+            not exhaust the available memory resources
+        :param unroll: Unrolling parameter for the outer and inner :func:`jax.lax.scan`
+            calls, allows for trade-offs between compilation and runtime cost; consult
+            the JAX docs for further information
         :return: Maximum mean discrepancy as a 0-dimensional array
         """
-        # Format inputs
-        reference_points = reference_data.data
-        num_reference_points = len(reference_points)
-        reference_weights = jnp.atleast_1d(reference_data.weights)
-        if jnp.allclose(
-            reference_weights,
-            jnp.broadcast_to(1 / num_reference_points, (num_reference_points,)),
-        ):
-            reference_weights = None
-
-        comparison_points = comparison_data.data
-        num_comparison_points = len(comparison_points)
-        comparison_weights = jnp.atleast_1d(comparison_data.weights)
-        if jnp.allclose(
-            comparison_weights,
-            jnp.broadcast_to(1 / num_comparison_points, (num_comparison_points,)),
-        ):
-            comparison_weights = None
-
-        if comparison_weights is None and reference_weights is None:
-            if block_size is None or block_size > max(
-                num_reference_points, num_comparison_points
-            ):
-                return self.maximum_mean_discrepancy(
-                    reference_points, comparison_points
-                )
-            return self.maximum_mean_discrepancy_block(
-                reference_points, comparison_points, block_size
-            )
-
-        if block_size is None or block_size > max(
-            num_reference_points, num_comparison_points
-        ):
-            return self.weighted_maximum_mean_discrepancy(
-                reference_points,
-                comparison_points,
-                reference_weights,
-                comparison_weights,
-            )
-
-        return self.weighted_maximum_mean_discrepancy_block(
-            reference_points,
-            comparison_points,
-            reference_weights,
-            comparison_weights,
-            block_size,
+        del kwargs
+        # Variable rename allows for nicer automatic formatting
+        x, y, bs = reference_data, comparison_data, block_size
+        kernel_nn_mean = self.kernel.compute_mean(x, x, block_size=bs, unroll=unroll)
+        kernel_mm_mean = self.kernel.compute_mean(y, y, block_size=bs, unroll=unroll)
+        kernel_nm_mean = self.kernel.compute_mean(x, y, block_size=bs, unroll=unroll)
+        squared_mmd_threshold_applied = coreax.util.apply_negative_precision_threshold(
+            kernel_nn_mean + kernel_mm_mean - 2 * kernel_nm_mean,
+            self.precision_threshold,
         )
-
-    def maximum_mean_discrepancy(
-        self, reference_points: ArrayLike, comparison_points: ArrayLike
-    ) -> Array:
-        r"""
-        Calculate standard, unweighted MMD.
-
-        For a dataset of ``n`` points in ``d`` dimensions, :math:`\mathcal_{D}_1`, and
-        another dataset :math:`\mathcal_{D}_2` of ``m`` points in ``d`` dimensions, the
-        maximum mean discrepancy is given by:
-
-        .. math::
-
-            \text{MMD}^2(\mathcal_{D}_1,\mathcal_{D}_2) = \mathbb{E}(k(\mathcal_{D}_1,
-            \mathcal_{D}_1)) + \mathbb{E}(k(\mathcal_{D}_2,\mathcal_{D}_2))
-            - 2\mathbb{E}(k(\mathcal_{D}_1,\mathcal_{D}_2))
-
-        where :math:`k` is the selected kernel.
-
-        :param reference_points: The original :math:`n \times d` data
-        :param comparison_points: An :math:`m \times d` array to compare to
-            ``reference_points``
-        :return: Maximum mean discrepancy as a 0-dimensional array
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        comparison_points = jnp.atleast_2d(comparison_points)
-
-        # Compute each term in the MMD formula
-        kernel_nn = self.kernel.compute(reference_points, reference_points)
-        kernel_mm = self.kernel.compute(comparison_points, comparison_points)
-        kernel_nm = self.kernel.compute(reference_points, comparison_points)
-
-        # Compute MMD
-        result = jnp.sqrt(
-            coreax.util.apply_negative_precision_threshold(
-                kernel_nn.mean() + kernel_mm.mean() - 2 * kernel_nm.mean(),
-                self.precision_threshold,
-            )
-        )
-        return result
-
-    def weighted_maximum_mean_discrepancy(
-        self,
-        reference_points: ArrayLike,
-        comparison_points: ArrayLike,
-        reference_weights: ArrayLike | None = None,
-        comparison_weights: ArrayLike | None = None,
-    ) -> Array:
-        r"""
-        Calculate weighted maximum mean discrepancy (WMMD).
-
-        :param reference_points: :math:`n \times d` array of reference data
-        :param comparison_points: An :math:`m \times d` array to compare to
-            ``reference_points``
-        :param reference_weights: :math:`m \times 1` weights vector for data
-            ``reference_points``, or :data:`None` (default) if unweighted
-        :param comparison_weights: :math:`m \times 1` weights vector for data
-            ``comparison_points``, or :data:`None` (default) if unweighted
-        :return: Weighted maximum mean discrepancy as a 0-dimensional array
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        num_reference_points = len(reference_points)
-        if reference_weights is None:
-            reference_weights = jnp.broadcast_to(
-                1 / num_reference_points, (num_reference_points,)
-            )
-        else:
-            reference_weights = jnp.atleast_1d(reference_weights)
-
-        comparison_points = jnp.atleast_2d(comparison_points)
-        num_comparison_points = len(comparison_points)
-        if comparison_weights is None:
-            comparison_weights = jnp.broadcast_to(
-                1 / num_comparison_points, (num_comparison_points,)
-            )
-        else:
-            comparison_weights = jnp.atleast_1d(comparison_weights)
-
-        # Compute each term in the weighted MMD formula
-        kernel_nn = self.kernel.compute(reference_points, reference_points)
-        kernel_mm = self.kernel.compute(comparison_points, comparison_points)
-        kernel_nm = self.kernel.compute(reference_points, comparison_points)
-
-        # Compute weighted MMD, correcting for any numerical precision issues, where we
-        # would otherwise square-root a negative number very close to 0.0.
-        result = jnp.sqrt(
-            coreax.util.apply_negative_precision_threshold(
-                jnp.dot(reference_weights.T, jnp.dot(kernel_nn, reference_weights))
-                / reference_weights.sum() ** 2
-                + jnp.dot(comparison_weights.T, jnp.dot(kernel_mm, comparison_weights))
-                / comparison_weights.sum() ** 2
-                - 2
-                * jnp.dot(jnp.dot(reference_weights.T, kernel_nm), comparison_weights)
-                / (reference_weights.sum() * comparison_weights.sum()),
-                self.precision_threshold,
-            )
-        )
-        return result
-
-    def maximum_mean_discrepancy_block(
-        self,
-        reference_points: ArrayLike,
-        comparison_points: ArrayLike,
-        block_size: int = 10_000,
-    ) -> Array:
-        r"""
-        Calculate maximum mean discrepancy (MMD) whilst limiting memory requirements.
-
-        :param reference_points: :math:`n \times d` array of reference data
-        :param comparison_points: An :math:`m \times d` array to compare to
-            ``reference_points``
-        :param block_size: Size of matrix blocks to process
-        :return: Maximum mean discrepancy as a 0-dimensional array
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        comparison_points = jnp.atleast_2d(comparison_points)
-
-        num_reference_points = float(len(reference_points))
-        num_comparison_points = float(len(comparison_points))
-
-        # Compute each term in the weighted MMD formula
-        kernel_nn = self.sum_pairwise_distances(
-            reference_points, reference_points, block_size
-        )
-        kernel_mm = self.sum_pairwise_distances(
-            comparison_points, comparison_points, block_size
-        )
-        kernel_nm = self.sum_pairwise_distances(
-            reference_points, comparison_points, block_size
-        )
-
-        # Compute MMD, correcting for any numerical precision issues, where we would
-        # otherwise square-root a negative number very close to 0.0.
-        result = jnp.sqrt(
-            coreax.util.apply_negative_precision_threshold(
-                kernel_nn / num_reference_points**2
-                + kernel_mm / num_comparison_points**2
-                - 2 * kernel_nm / (num_reference_points * num_comparison_points),
-                self.precision_threshold,
-            )
-        )
-        return result
-
-    def weighted_maximum_mean_discrepancy_block(
-        self,
-        reference_points: ArrayLike,
-        comparison_points: ArrayLike,
-        reference_weights: ArrayLike,
-        comparison_weights: ArrayLike,
-        block_size: int = 10_000,
-    ) -> Array:
-        r"""
-        Calculate weighted maximum mean discrepancy (MMD).
-
-        This calculation is executed whilst limiting memory requirements.
-
-        :param reference_points: :math:`n \times d` array of reference data
-        :param comparison_points: An :math:`m \times d` array to compare to
-            ``reference_points```
-        :param reference_weights: :math:`n` weights of reference data
-        :param comparison_weights: :math:`m` weights of points in ``comparison_points``
-        :param block_size: Size of matrix blocks to process
-        :return: Maximum mean discrepancy as a 0-dimensional array
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        comparison_points = jnp.atleast_2d(comparison_points)
-        reference_weights = jnp.atleast_1d(reference_weights)
-        comparison_weights = jnp.atleast_1d(comparison_weights)
-
-        num_reference_points = reference_weights.sum()
-        num_comparison_points = comparison_weights.sum()
-
-        kernel_nn = self.sum_weighted_pairwise_distances(
-            reference_points,
-            reference_points,
-            reference_weights,
-            reference_weights,
-            block_size,
-        )
-        kernel_mm = self.sum_weighted_pairwise_distances(
-            comparison_points,
-            comparison_points,
-            comparison_weights,
-            comparison_weights,
-            block_size,
-        )
-        kernel_nm = self.sum_weighted_pairwise_distances(
-            reference_points,
-            comparison_points,
-            reference_weights,
-            comparison_weights,
-            block_size,
-        )
-
-        # Compute MMD, correcting for any numerical precision issues, where we would
-        # otherwise square-root a negative number very close to 0.0.
-        result = jnp.sqrt(
-            coreax.util.apply_negative_precision_threshold(
-                kernel_nn / num_reference_points**2
-                + kernel_mm / num_comparison_points**2
-                - 2 * kernel_nm / (num_reference_points * num_comparison_points),
-                self.precision_threshold,
-            )
-        )
-        return result
-
-    def sum_pairwise_distances(
-        self,
-        reference_points: ArrayLike,
-        comparison_points: ArrayLike,
-        block_size: int = 10_000,
-    ) -> float:
-        r"""
-        Sum the kernel distance between all pairs of points in the two input datasets.
-
-        The summation is done in blocks to avoid excessive memory usage.
-
-        :param reference_points: :math:`n \times 1` array
-        :param comparison_points: :math:`m \times 1` array
-        :param block_size: Size of matrix blocks to process
-        :return: The sum of pairwise distances between points in ``reference_points``
-            and ``comparison_points``
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        comparison_points = jnp.atleast_2d(comparison_points)
-        block_size = max(0, block_size)
-
-        num_reference_points = len(reference_points)
-        num_comparison_points = len(comparison_points)
-
-        # If block_size is larger than both inputs, we don't need to consider block-wise
-        # computation
-        if block_size > max(num_reference_points, num_comparison_points):
-            pairwise_distance_sum = self.kernel.compute(
-                reference_points, comparison_points
-            ).sum()
-
-        else:
-            try:
-                row_index_range = range(0, num_reference_points, block_size)
-            except ValueError as exception:
-                if block_size == 0:
-                    raise ValueError(
-                        "block_size must be a positive integer"
-                    ) from exception
-                raise
-            except TypeError as exception:
-                raise TypeError("block_size must be a positive integer") from exception
-
-            pairwise_distance_sum = 0
-            for i in row_index_range:
-                for j in range(0, num_comparison_points, block_size):
-                    pairwise_distances_part = self.kernel.compute(
-                        reference_points[i : i + block_size],
-                        comparison_points[j : j + block_size],
-                    )
-                    pairwise_distance_sum += pairwise_distances_part.sum()
-
-        return pairwise_distance_sum
-
-    def sum_weighted_pairwise_distances(
-        self,
-        reference_points: ArrayLike,
-        comparison_points: ArrayLike,
-        reference_weights: ArrayLike,
-        comparison_weights: ArrayLike,
-        block_size: int = 10_000,
-    ) -> float:
-        r"""
-        Sum weighted kernel distance between all pairs of points in the two datasets.
-
-        The summation is done in blocks to avoid excessive memory usage.
-
-        :param reference_points: :math:`n \times 1` array
-        :param comparison_points: :math:`m \times 1` array
-        :param reference_weights: :math:`n \times 1` array of weights for
-            ``reference_points``
-        :param comparison_weights: :math:`m \times 1` array of weights for
-            ``comparison_points``
-        :param block_size: Size of matrix blocks to process
-        :return: The sum of pairwise distances between points in ``reference_points``
-            and ``comparison_points``, with contributions weighted as defined by
-            ``reference_weights`` and ``comparison_weights``
-        """
-        # Format inputs
-        reference_points = jnp.atleast_2d(reference_points)
-        comparison_points = jnp.atleast_2d(comparison_points)
-        reference_weights = jnp.atleast_1d(reference_weights)
-        comparison_weights = jnp.atleast_1d(comparison_weights)
-        block_size = max(0, block_size)
-
-        num_reference_points = len(reference_points)
-        num_comparison_points = len(comparison_points)
-
-        # If block_size is larger than both inputs, we don't need to consider block-wise
-        # computation
-        if block_size > max(num_reference_points, num_comparison_points):
-            kernel_weights = (
-                self.kernel.compute(reference_points, comparison_points)
-                * comparison_weights
-            )
-            weighted_pairwise_distance_sum = (
-                reference_weights * kernel_weights.T
-            ).sum()
-
-        else:
-            weighted_pairwise_distance_sum = 0
-
-            try:
-                row_index_range = range(0, num_reference_points, block_size)
-            except ValueError as exception:
-                if block_size == 0:
-                    raise ValueError(
-                        "block_size must be a positive integer"
-                    ) from exception
-                raise
-            except TypeError as exception:
-                raise TypeError("block_size must be a positive integer") from exception
-
-            for i in row_index_range:
-                for j in range(0, num_comparison_points, block_size):
-                    pairwise_distances_part = (
-                        reference_weights[i : i + block_size, None]
-                        * self.kernel.compute(
-                            reference_points[i : i + block_size],
-                            comparison_points[j : j + block_size],
-                        )
-                        * comparison_weights[None, j : j + block_size]
-                    )
-                    weighted_pairwise_distance_sum += pairwise_distances_part.sum()
-
-        return weighted_pairwise_distance_sum
+        return jnp.sqrt(squared_mmd_threshold_applied)

--- a/coreax/metrics.py
+++ b/coreax/metrics.py
@@ -26,6 +26,7 @@ module, all of which implement :class:`Metric`.
 from __future__ import annotations
 
 from abc import abstractmethod
+from itertools import product
 from typing import Generic, TypeVar
 
 import equinox as eqx
@@ -119,34 +120,15 @@ class MMD(Metric[_Data]):
         :return: Maximum mean discrepancy as a 0-dimensional array
         """
         del kwargs
-        bs_nn, bs_mm, bs_nm, _ = _permuted_block_sizes(block_size)
+        _block_size = coreax.util.tree_leaves_repeat(block_size, 2)
+        bs_xx, bs_xy, _, bs_yy = tuple(product(_block_size, repeat=len(_block_size)))
         # Variable rename allows for nicer automatic formatting
         x, y = reference_data, comparison_data
-        kernel_nn_mean = self.kernel.compute_mean(x, x, block_size=bs_nn, unroll=unroll)
-        kernel_mm_mean = self.kernel.compute_mean(y, y, block_size=bs_mm, unroll=unroll)
-        kernel_nm_mean = self.kernel.compute_mean(x, y, block_size=bs_nm, unroll=unroll)
+        kernel_xx_mean = self.kernel.compute_mean(x, x, block_size=bs_xx, unroll=unroll)
+        kernel_yy_mean = self.kernel.compute_mean(y, y, block_size=bs_yy, unroll=unroll)
+        kernel_xy_mean = self.kernel.compute_mean(x, y, block_size=bs_xy, unroll=unroll)
         squared_mmd_threshold_applied = coreax.util.apply_negative_precision_threshold(
-            kernel_nn_mean + kernel_mm_mean - 2 * kernel_nm_mean,
+            kernel_xx_mean + kernel_yy_mean - 2 * kernel_xy_mean,
             self.precision_threshold,
         )
         return jnp.sqrt(squared_mmd_threshold_applied)
-
-
-def _permuted_block_sizes(
-    block_size: int | None | tuple[int | None, int | None],
-) -> tuple[tuple[int | None, int | None], ...]:
-    """
-    Generate all permutations of the passed block sizes.
-
-    :param block_size: Size of matrix blocks to process; a value of :data:`None`
-        sets :math:`B_x = n` and :math:`B_y = m`, effectively disabling the block
-        accumulation; an integer value ``B`` sets :math:`B_y = B_x = B`; a tuple
-        allows different sizes to be specified for ``B_x`` and ``B_y``
-    :return: Given a block size :math:`B`, returns the permutations :math:`(B_x, B_x)`,
-        :math:`(B_y, B_y)`, :math:`(B_x, B_y)` and :math:`(B_y, B_x)`
-    """
-    operand_count = 2
-    bs_nm = tuple(coreax.util.tree_leaves_repeat(block_size, operand_count))
-    bs_mn = bs_nm[::-1]
-    bs_nn, bs_mm = bs_nm[:1] * operand_count, bs_nm[1:] * operand_count
-    return bs_nn, bs_mm, bs_nm, bs_mn

--- a/coreax/reduction.py
+++ b/coreax/reduction.py
@@ -222,7 +222,7 @@ class Coreset(ABC):
         )
         coreset_data = coreax.data.Data(data=self.coreset, weights=weights_y)
 
-        return metric.compute(pre_coreset_data, coreset_data, block_size)
+        return metric.compute(pre_coreset_data, coreset_data, block_size=block_size)
 
     def refine(self) -> None:
         """

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -58,8 +58,8 @@ class InvalidKernel:
 
 
 def apply_negative_precision_threshold(
-    x: float, precision_threshold: float = 1e-8
-) -> float:
+    x: ArrayLike, precision_threshold: float = 1e-8
+) -> Array:
     """
     Round a number to 0.0 if it is negative but within precision_threshold of 0.0.
 
@@ -67,12 +67,8 @@ def apply_negative_precision_threshold(
     :param precision_threshold: Positive threshold we compare against for precision
     :return: ``x``, rounded to 0.0 if it is between ``-precision_threshold`` and 0.0
     """
-    if precision_threshold < 0.0:
-        raise ValueError("precision_threshold must not be negative.")
-    if -precision_threshold < x < 0.0:
-        return 0.0
-
-    return x
+    _x = jnp.asarray(x)
+    return jnp.where((-jnp.abs(precision_threshold) < _x) & (_x < 0.0), 0.0, _x)
 
 
 def pairwise(

--- a/documentation/source/coreax/metrics.rst
+++ b/documentation/source/coreax/metrics.rst
@@ -2,3 +2,4 @@ Metrics
 ========
 
 .. automodule:: coreax.metrics
+    :no-undoc-members:

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,206 +19,57 @@ Metrics evaluate the quality of a coreset by some measure. The tests within this
 verify that metric computations produce the expected results on simple examples.
 """
 
-import unittest
-from unittest.mock import MagicMock, patch
+from typing import Literal, NamedTuple
 
 import jax.numpy as jnp
-from jax import random
+import jax.random as jr
+import jax.tree_util as jtu
+import pytest
+from jax import Array
 
-import coreax.data
-import coreax.kernel
 import coreax.metrics
-from coreax.util import pairwise, squared_distance
-
-# pylint: disable=too-many-public-methods
-
-
-class TestMetrics(unittest.TestCase):
-    r"""
-    Tests related to Metric abstract base class in metrics.py.
-    """
-
-    def test_metric_creation(self) -> None:
-        r"""
-        Test the class Metric initialises correctly.
-        """
-        # Disable pylint warning for abstract-class-instantiated as we are patching
-        # these whilst testing creation of the parent class
-        # pylint: disable=abstract-class-instantiated
-        # Patch the abstract methods of the Metric ABC, so it can be created
-        p = patch.multiple(coreax.metrics.Metric, __abstractmethods__=set())
-        p.start()
-
-        # Create a metric object
-        metric = coreax.metrics.Metric()
-        # pylint: enable=abstract-class-instantiated
-
-        # Check the compute method exists
-        self.assertTrue(hasattr(metric, "compute"))
+from coreax.data import Data
+from coreax.kernel import Kernel, LaplacianKernel, PCIMQKernel, SquaredExponentialKernel
 
 
-class TestMMD(unittest.TestCase):
+class _MetricProblem(NamedTuple):
+    reference_data: Data
+    comparison_data: Data
+
+
+class TestMMD:
     """
     Tests related to the maximum mean discrepancy (MMD) class in metrics.py.
     """
 
-    # Disable pylint warning for too-many-instance-attributes as we use each of these in
-    # subsequent tests, variable names ensure human readability and understanding
-    # pylint: disable=too-many-instance-attributes
-    def setUp(self):
+    @pytest.fixture
+    def problem(self) -> _MetricProblem:
+        """Generate an example problem for testing MMD."""
+        dimension = 10
+        num_points = 30, 5
+        keys = tuple(jr.split(jr.key(0), 2))
+
+        def _generate_data(_num_points: int, _key: Array) -> Data:
+            point_key, weight_key = jr.split(_key, 2)
+            points = jr.uniform(point_key, (_num_points, dimension))
+            weights = jr.uniform(weight_key, (_num_points,))
+            return Data(points, weights)
+
+        reference_data, comparison_data = jtu.tree_map(_generate_data, num_points, keys)
+        return _MetricProblem(reference_data, comparison_data)
+
+    @pytest.mark.parametrize(
+        "kernel", [SquaredExponentialKernel(), LaplacianKernel(), PCIMQKernel()]
+    )
+    def test_mmd_compare_same_data(self, problem: _MetricProblem, kernel: Kernel):
+        """Check MMD of a dataset with itself is approximately zero."""
+        x = problem.reference_data
+        metric = coreax.metrics.MMD(kernel)
+        assert metric.compute(x, x) == pytest.approx(0.0)
+
+    def test_mmd_analytically_known(self):
         r"""
-        Generate data for shared use across unit tests.
-
-        Generate ``num_reference_points`` random points in ``d`` dimensions from a
-        uniform distribution [0, 1).
-        Randomly select ``num_comparison_points`` points for second dataset
-        ``comparison_data``.
-        Generate weights: ``reference_weights`` for reference data,
-        ``comparison_weights`` for comparison data.
-
-        :num_reference_points: Number of test data points
-        :d: Dimension of data
-        :num_comparison_points: Number of points to randomly select for comparison data
-        :block_size: Maximum number of points for block calculations
-        """
-        # Define data parameters
-        self.num_reference_points = 30
-        self.dimension = 10
-        self.num_comparison_points = 5
-        self.block_size = 3
-
-        # Define example datasets
-        self.reference_points = random.uniform(
-            random.key(0), shape=(self.num_reference_points, self.dimension)
-        )
-        self.reference_weights = (
-            random.uniform(random.key(0), shape=(self.num_reference_points,))
-            / self.num_reference_points
-        )
-        self.reference_data = coreax.data.Data(
-            data=self.reference_points, weights=self.reference_weights
-        )
-
-        self.comparison_points = random.choice(
-            random.key(0), self.reference_points, shape=(self.num_comparison_points,)
-        )
-        self.comparison_weights = (
-            random.uniform(random.key(0), shape=(self.num_comparison_points,))
-            / self.num_comparison_points
-        )
-        self.comparison_data = coreax.data.Data(
-            data=self.comparison_points, weights=self.comparison_weights
-        )
-
-    def test_mmd_compare_same_data(self) -> None:
-        r"""
-        Test the MMD of a dataset with itself is zero, for several different kernels.
-        """
-        # Define a metric object using the SquaredExponentialKernel
-        metric = coreax.metrics.MMD(
-            kernel=coreax.kernel.SquaredExponentialKernel(length_scale=1.0)
-        )
-        self.assertAlmostEqual(
-            float(
-                metric.maximum_mean_discrepancy(
-                    self.reference_points, self.reference_points
-                )
-            ),
-            0.0,
-        )
-
-        # Define a metric object using the LaplacianKernel
-        metric = coreax.metrics.MMD(
-            kernel=coreax.kernel.LaplacianKernel(length_scale=1.0)
-        )
-        self.assertAlmostEqual(
-            float(
-                metric.maximum_mean_discrepancy(
-                    self.reference_points, self.reference_points
-                )
-            ),
-            0.0,
-        )
-
-        # Define a metric object using the PCIMQKernel
-        metric = coreax.metrics.MMD(kernel=coreax.kernel.PCIMQKernel(length_scale=1.0))
-        self.assertAlmostEqual(
-            float(
-                metric.maximum_mean_discrepancy(
-                    self.reference_points, self.reference_points
-                )
-            ),
-            0.0,
-        )
-
-    def test_mmd_ones(self):
-        r"""
-        Test MMD computation with a small example dataset of ones and zeros.
-
-        For the dataset of 4 points in 2 dimensions, :math:`\mathcal{D}_1`, and another
-        dataset :math:`\mathcal{D}_2`, given by:
-
-        .. math::
-
-            reference_data = [[0,0], [1,1], [0,0], [1,1]]
-
-            comparison_data = [[0,0], [1,1]]
-
-        the Gaussian (aka radial basis function) kernel,
-        :math:`k(x,y) = \exp (-||x-y||^2/2\sigma^2)`, gives:
-
-        .. math::
-
-            k(\mathcal{D}_1,x) = \exp(-\begin{bmatrix}0 & 2 & 0 & 2 \\ 2 & 0 & 2 & 0\\
-            0 & 2 & 0 & 2 \\ 2 & 0 & 2 & 0\end{bmatrix}/2\sigma^2).
-
-            k(\mathcal{D}_2,\mathcal{D}_2) = \exp(-\begin{bmatrix}0 & 2  \\ 2 & 0
-            \end{bmatrix}/2\sigma^2).
-
-            k(\mathcal{D}_1,\mathcal{D}_2) = \exp(-\begin{bmatrix}0 & 2  \\ 2 & 0
-            \\0 & 2  \\ 2 & 0
-            \end{bmatrix}/2\sigma^2).
-
-        Then
-
-        .. math::
-
-            \text{MMD}^2(\mathcal{D}_1,\mathcal{D}_2) = \mathbb{E}(k(\mathcal{D}_1,
-            \mathcal{D}_1))
-            + \mathbb{E}(k(\mathcal{D}_2,\mathcal{D}_2)) - 2\mathbb{E}(k(\mathcal{D}_1,
-            \mathcal{D}_2))
-
-            = \frac{1}{2} + e^{-1/2} + \frac{1}{2} + e^{-1/2} - 2\left(\frac{1}{2}
-            + e^{-1/2}\right)
-
-            = 0.
-        """
-        # Setup data
-        reference_points = jnp.array([[0, 0], [1, 1], [0, 0], [1, 1]])
-        reference_data = coreax.data.Data(data=reference_points)
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-        comparison_data = coreax.data.Data(data=comparison_points)
-        length_scale = 1.0
-
-        # Set expected MMD
-        expected_output = 0.0
-
-        # Define a metric object using an RBF kernel
-        metric = coreax.metrics.MMD(
-            kernel=coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        )
-
-        # Compute MMD using the metric object
-        output = metric.compute(
-            reference_data=reference_data, comparison_data=comparison_data
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(float(output), expected_output, places=5)
-
-    def test_mmd_ints(self):
-        r"""
-        Test MMD computation with a small example dataset of integers.
+        Test MMD computation against an analytically derived solution.
 
         For the dataset of 3 points in 2 dimensions, :math:`\mathcal{D}_1`, and second
         dataset :math:`\mathcal{D}_2`, given by:
@@ -261,62 +112,19 @@ class TestMMD(unittest.TestCase):
 
             = \frac{3 - e^{-1} -2e^{-4}}{18}.
         """
-        # Setup data
         reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        reference_data = coreax.data.Data(data=reference_points)
+        reference_data = Data(data=reference_points)
         comparison_points = jnp.array([[0, 0], [1, 1]])
-        comparison_data = coreax.data.Data(data=comparison_points)
-        length_scale = 1.0
-
-        # Set expected MMD
+        comparison_data = Data(data=comparison_points)
         expected_output = jnp.sqrt((3 - jnp.exp(-1) - 2 * jnp.exp(-4)) / 18)
-
-        # Define a metric object using an RBF kernel
-        metric = coreax.metrics.MMD(
-            kernel=coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        )
-
         # Compute MMD using the metric object
-        output = metric.compute(
-            reference_data=reference_data, comparison_data=comparison_data
-        )
+        metric = coreax.metrics.MMD(SquaredExponentialKernel())
+        output = metric.compute(reference_data, comparison_data)
+        assert output == pytest.approx(expected_output)
 
-        # Check output matches expected
-        self.assertAlmostEqual(float(output), float(expected_output), places=5)
-
-    def test_mmd_rand(self):
+    def test_mmd_analytically_known_weighted(self) -> None:
         r"""
-        Test MMD computed from randomly generated test data agrees with method result.
-        """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Compute each term in the MMD formula
-        kernel_nn = kernel.compute(self.reference_points, self.reference_points)
-        kernel_mm = kernel.compute(self.comparison_points, self.comparison_points)
-        kernel_nm = kernel.compute(self.reference_points, self.comparison_points)
-
-        # Compute overall MMD by
-        expected_mmd = (
-            kernel_nn.mean() + kernel_mm.mean() - 2 * kernel_nm.mean()
-        ) ** 0.5
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute MMD using the metric object
-        output = metric.maximum_mean_discrepancy(
-            reference_points=self.reference_points,
-            comparison_points=self.comparison_points,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_mmd, places=5)
-
-    def test_weighted_mmd_ints(self) -> None:
-        r"""
-        Test weighted MMD computation with a small example dataset of integers.
+        Test MMD computation against an analytically derived weighted solution.
 
         Weighted mmd is calculated if and only if comparison_weights are provided. When
         `comparison_weights` = :data:`None`, the MMD class computes the standard,
@@ -350,813 +158,56 @@ class TestMMD(unittest.TestCase):
 
             = \frac{2}{3} - \frac{2}{9}e^{-1} - \frac{4}{9}e^{-4}.
         """
-        # Setup data
         reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
         reference_weights = jnp.array([1, 1, 1])
-        reference_data = coreax.data.Data(
-            data=reference_points, weights=reference_weights
-        )
+        reference_data = Data(reference_points, reference_weights)
         comparison_points = jnp.array([[0, 0], [1, 1]])
         comparison_weights = jnp.array([1, 0])
-        comparison_data = coreax.data.Data(
-            data=comparison_points, weights=comparison_weights
-        )
-        length_scale = 1.0
-
-        # Define expected output
+        comparison_data = Data(comparison_points, comparison_weights)
         expected_output = jnp.sqrt(
             2 / 3 - (2 / 9) * jnp.exp(-1) - (4 / 9) * jnp.exp(-4)
         )
+        # Compute the weighted MMD using the metric object
+        metric = coreax.metrics.MMD(SquaredExponentialKernel())
+        output = metric.compute(reference_data, comparison_data)
+        assert output == pytest.approx(expected_output)
 
-        # Define a metric object
-        metric = coreax.metrics.MMD(
-            kernel=coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-        )
-
-        # Compute weighted mmd using the metric object
-        output = metric.compute(
-            reference_data=reference_data,
-            comparison_data=comparison_data,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(float(output), float(expected_output), places=5)
-
-    def test_weighted_mmd_rand(self) -> None:
+    @pytest.mark.parametrize("mode", ["unweighted", "weighted"])
+    def test_mmd_random_data(
+        self, problem: _MetricProblem, mode: Literal["unweighted", "weighted"]
+    ):
         r"""
-        Test weighted MMD computations on randomly generated test data.
+        Test MMD computed from randomly generated test data agrees with method result.
+
+        - "unweighted" parameterization checks that if the 'reference_data' and the
+            'comparison_data' have the default 'None' weights, that the computed MMD is
+            given by the means of the unweighted kernel matrices.
+        - "weighted" parameterization checks that for arbitrarily weighted data, the
+            computed MMD is given by the weighted average of the kernel matrices.
         """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Compute each term in the MMD formula
-        kernel_nn = kernel.compute(self.reference_points, self.reference_points)
-        kernel_mm = kernel.compute(self.comparison_points, self.comparison_points)
-        kernel_nm = kernel.compute(self.reference_points, self.comparison_points)
-
-        # Define expected output
-        comparison_weights = self.comparison_data.weights
-        reference_weights = self.reference_data.weights
-        expected_output = jnp.sqrt(
-            jnp.dot(reference_weights.T, jnp.dot(kernel_nn, reference_weights))
-            / reference_weights.sum() ** 2
-            + jnp.dot(comparison_weights.T, jnp.dot(kernel_mm, comparison_weights))
-            / comparison_weights.sum() ** 2
-            - 2
-            * jnp.dot(jnp.dot(reference_weights.T, kernel_nm), comparison_weights)
-            / (reference_weights.sum() * comparison_weights.sum())
-        )
-
-        # Define a metric object
+        kernel = SquaredExponentialKernel()
+        x, y = problem
+        # Compute each term in the MMD formula to obtain an expected MMD.
+        kernel_nn = kernel.compute(x.data, x.data)
+        kernel_mm = kernel.compute(y.data, y.data)
+        kernel_nm = kernel.compute(x.data, y.data)
+        if mode == "weighted":
+            weights_nn = x.weights[..., None] * x.weights[None, ...]
+            weights_mm = y.weights[..., None] * y.weights[None, ...]
+            weights_nm = x.weights[..., None] * y.weights[None, ...]
+            expected_mmd = jnp.sqrt(
+                jnp.average(kernel_nn, weights=weights_nn)
+                + jnp.average(kernel_mm, weights=weights_mm)
+                - 2 * jnp.average(kernel_nm, weights=weights_nm)
+            )
+        elif mode == "unweighted":
+            x, y = Data(x.data), Data(y.data)
+            expected_mmd = jnp.sqrt(
+                jnp.mean(kernel_nn) + jnp.mean(kernel_mm) - 2 * jnp.mean(kernel_nm)
+            )
+        else:
+            raise ValueError("Invalid mode parameterization")
+        # Compute the MMD using the metric object
         metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute weighted MMD using the metric object
-        output = metric.weighted_maximum_mean_discrepancy(
-            reference_points=self.reference_points,
-            comparison_points=self.comparison_points,
-            reference_weights=self.reference_weights,
-            comparison_weights=self.comparison_weights,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_weighted_mmd_uniform_weights(self) -> None:
-        r"""
-        Test that weighted MMD equals MMD if weights are uniform.
-
-        Uniform weights are such that :math:`w_1 = 1/n` and :math:`w_2 = 1/m`.
-        """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute weighted MMD with all weights being uniform
-        uniform_wmmd = metric.weighted_maximum_mean_discrepancy(
-            reference_points=self.reference_points,
-            comparison_points=self.comparison_points,
-            reference_weights=jnp.ones(self.num_reference_points)
-            / self.num_reference_points,
-            comparison_weights=jnp.ones(self.num_comparison_points)
-            / self.num_comparison_points,
-        )
-
-        # Compute MMD without the weights
-        mmd = metric.maximum_mean_discrepancy(
-            self.reference_points, self.comparison_points
-        )
-
-        # Check uniform weighted MMD and MMD without weights give the same result
-        self.assertAlmostEqual(float(uniform_wmmd), float(mmd), places=5)
-
-    def test_sum_pairwise_distances(self) -> None:
-        r"""
-        Test sum_pairwise_distances() with a small integer example.
-
-        For the dataset of 3 points in 2 dimensions :math:`\mathcal{D}_1`, and second
-        dataset :math:`\mathcal{D}_2`:
-
-        .. math::
-
-            reference_data = [[0,0], [1,1], [2,2]]
-
-            comparison_data = [[0,0], [1,1]]
-
-        the pairwise square distances are given by the matrix:
-
-        .. math::
-
-            \begin{bmatrix}0 & 2 \\ 2 & 0 \\ 8 & 2 \end{bmatrix}
-
-        which, summing across both axes, gives the result :math:`14`.
-        """
-        # Setup data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-
-        # Set expected output
-        expected_output = 14
-
-        # Define a kernel object and set pairwise computations to be the square distance
-        kernel = MagicMock()
-        kernel.compute = pairwise(squared_distance)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute the sum of pairwise distances using the metric object
-        output = metric.sum_pairwise_distances(
-            reference_points=reference_points,
-            comparison_points=comparison_points,
-            block_size=2,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_sum_pairwise_distances_large_block_size(self) -> None:
-        r"""
-        Test sum_pairwise_distances() with a block size larger than the input data.
-
-        This test uses the same data as `test_sum_pairwise_distances` above, and so
-        expects to get exactly the same output. The difference between the tests is,
-        here ``block_size`` is large enough to not need block-wise computation.
-        """
-        # Setup data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-
-        # Set expected output
-        expected_output = 14
-
-        # Define a kernel object and set pairwise computations to be the square distance
-        kernel = MagicMock()
-        kernel.compute = pairwise(squared_distance)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute the sum of pairwise distances using the metric object
-        output = metric.sum_pairwise_distances(
-            reference_points=reference_points,
-            comparison_points=comparison_points,
-            block_size=2000,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_sum_pairwise_distances_zero_block_size(self):
-        """
-        Test sum_pairwise_distances when a zero block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of pairwise distances with a zero block_size - this should
-        # raise an error highlighting that block_size should be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.sum_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_sum_pairwise_distances_negative_block_size(self):
-        """
-        Test sum_pairwise_distances when a negative block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of pairwise distances with a negative block_size - this should
-        # raise an error highlighting that block_size should be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.sum_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=-5,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_sum_pairwise_distances_float_block_size(self):
-        """
-        Test sum_pairwise_distances when a float block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of pairwise distances with a float block_size - this should
-        # raise an error highlighting that block_size should be a positive integer
-        with self.assertRaises(TypeError) as error_raised:
-            metric.sum_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=2.0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_maximum_mean_discrepancy_block_ints(self) -> None:
-        r"""
-        Test maximum_mean_discrepancy_block while limiting memory requirements.
-
-        This test uses the same 2D, three-point dataset and second dataset as
-        test_mmd_ints().
-        """
-        # Setup data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        reference_data = coreax.data.Data(data=reference_points)
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-        comparison_data = coreax.data.Data(data=comparison_points)
-
-        # Define expected output
-        expected_output = jnp.sqrt((3 - jnp.exp(-1) - 2 * jnp.exp(-4)) / 18)
-
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute MMD block-wise
-        mmd_block_test = metric.compute(
-            reference_data=reference_data, comparison_data=comparison_data, block_size=2
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(float(mmd_block_test), float(expected_output), places=5)
-
-    def test_maximum_mean_discrepancy_block_rand(self) -> None:
-        r"""
-        Test that mmd block-computed for random test data equals method output.
-        """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Compute MMD term with x and itself
-        kernel_nn = 0.0
-        for i1 in range(0, self.num_reference_points, self.block_size):
-            for i2 in range(0, self.num_reference_points, self.block_size):
-                kernel_nn += kernel.compute(
-                    self.reference_points[i1 : i1 + self.block_size, :],
-                    self.reference_points[i2 : i2 + self.block_size, :],
-                ).sum()
-
-        # Compute MMD term with y and itself
-        kernel_mm = 0.0
-        for j1 in range(0, self.num_comparison_points, self.block_size):
-            for j2 in range(0, self.num_comparison_points, self.block_size):
-                kernel_mm += kernel.compute(
-                    self.comparison_points[j1 : j1 + self.block_size, :],
-                    self.comparison_points[j2 : j2 + self.block_size, :],
-                ).sum()
-
-        # Compute MMD term with x and y
-        kernel_nm = 0.0
-        for i in range(0, self.num_reference_points, self.block_size):
-            for j in range(0, self.num_comparison_points, self.block_size):
-                kernel_nm += kernel.compute(
-                    self.reference_points[i : i + self.block_size, :],
-                    self.comparison_points[j : j + self.block_size, :],
-                ).sum()
-
-        # Compute expected output from MMD
-        expected_output = (
-            kernel_nn / self.num_reference_points**2
-            + kernel_mm / self.num_comparison_points**2
-            - 2 * kernel_nm / (self.num_reference_points * self.num_comparison_points)
-        ) ** 0.5
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute MMD
-        output = metric.maximum_mean_discrepancy_block(
-            self.reference_points, self.comparison_points, block_size=self.block_size
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_maximum_mean_discrepancy_equals_maximum_mean_discrepancy_block(
-        self,
-    ) -> None:
-        r"""
-        Test that MMD computations agree when done block-wise and all at once.
-        """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Check outputs are the same
-        self.assertAlmostEqual(
-            float(
-                metric.maximum_mean_discrepancy(
-                    self.reference_points, self.comparison_points
-                )
-            ),
-            float(
-                metric.maximum_mean_discrepancy_block(
-                    self.reference_points,
-                    self.comparison_points,
-                    block_size=self.block_size,
-                )
-            ),
-            places=5,
-        )
-
-    def test_maximum_mean_discrepancy_block_zero_block_size(self) -> None:
-        """
-        Test maximum_mean_discrepancy_block when given a zero block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a zero block_size - the full text of the inbuilt error raised
-        # from the range function should provide all information needed for users to
-        # identify the issue
-        with self.assertRaises(ValueError) as error_raised:
-            metric.maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_maximum_mean_discrepancy_block_negative_block_size(self) -> None:
-        """
-        Test maximum_mean_discrepancy_block when given a negative block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a negative block_size - this should raise an error
-        # highlighting that block_size should be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=-2,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_maximum_mean_discrepancy_block_float_block_size(self) -> None:
-        """
-        Test maximum_mean_discrepancy_block when given a float block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a float block_size - an error should be raised highlighting
-        # this should be a positive integer
-        with self.assertRaises(TypeError) as error_raised:
-            metric.maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                block_size=1.0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_sum_weighted_pairwise_distances(self) -> None:
-        r"""
-        Test sum_weighted_pairwise_distances, which calculates w^T*K*w matrices.
-
-        Computations are done in blocks of size block_size.
-
-        For the dataset of 3 points in 2 dimensions :math:`\mathcal{D}_1`, and second
-        dataset :math:`\mathcal{D}_2`:
-
-        .. math::
-
-            reference_data = [[0,0], [1,1], [2,2]]
-
-            comparison_data = [[0,0], [1,1]]
-
-        the pairwise square distances are given by the matrix:
-
-        .. math::
-
-            k(\mathcal{D}_1, \mathcal{D}_2) = \begin{bmatrix}0 & 2 \\ 2 & 0 \\ 8 & 2
-            \end{bmatrix}.
-
-        Then, for weights vectors:
-
-        .. math::
-
-            w = [0.5, 0.5, 0],
-
-            w_comparison_data = [1, 0]
-
-        the product :math:`w^T*k(\mathcal{D}_1, \mathcal{D}_2)*w_comparison_data = 1`.
-        """
-        # Setup some data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-        reference_weights = jnp.array([0.5, 0.5, 0])
-        comparison_weights = jnp.array([1, 0])
-
-        # Define expected output
-        expected_output = 1.0
-
-        # Define a kernel object and set pairwise computations to be the square distance
-        kernel = MagicMock()
-        kernel.compute = pairwise(squared_distance)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute sum of weighted pairwise distances
-        output = metric.sum_weighted_pairwise_distances(
-            reference_points=reference_points,
-            comparison_points=comparison_points,
-            reference_weights=reference_weights,
-            comparison_weights=comparison_weights,
-            block_size=2,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_sum_weighted_pairwise_distances_big_block_size(self) -> None:
-        r"""
-        Test sum_weighted_pairwise_distances with block size larger than the input data.
-
-        This test uses the same data as `test_sum_weighted_pairwise_distances` above,
-        and so expects to get exactly the same output. The difference between the tests
-        is, here ``block_size`` is large enough to not need block-wise computation.
-        """
-        # Setup some data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-        reference_weights = jnp.array([0.5, 0.5, 0])
-        comparison_weights = jnp.array([1, 0])
-
-        # Define expected output
-        expected_output = 1.0
-
-        # Define a kernel object and set pairwise computations to be the square distance
-        kernel = MagicMock()
-        kernel.compute = pairwise(squared_distance)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute sum of weighted pairwise distances
-        output = metric.sum_weighted_pairwise_distances(
-            reference_points=reference_points,
-            comparison_points=comparison_points,
-            reference_weights=reference_weights,
-            comparison_weights=comparison_weights,
-            block_size=2000,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(output, expected_output, places=5)
-
-    def test_sum_weighted_pairwise_distances_zero_block_size(self):
-        """
-        Test sum_weighted_pairwise_distances when a zero block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of weighted pairwise distances with a zero block_size - this
-        # should error and state a positive integer is required
-        with self.assertRaises(ValueError) as error_raised:
-            metric.sum_weighted_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_sum_weighted_pairwise_distances_negative_block_size(self):
-        """
-        Test sum_weighted_pairwise_distances when a negative block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of weighted pairwise distances with a negative block_size - this
-        # should raise an error highlighting that block_size should be a positive
-        # integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.sum_weighted_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=-5,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_sum_weighted_pairwise_distances_float_block_size(self):
-        """
-        Test sum_weighted_pairwise_distances when a float block size is given.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute sum of weighted pairwise distances with a float block_size - this
-        # should raise an error highlighting that block_size should be a positive
-        # integer
-        with self.assertRaises(TypeError) as error_raised:
-            metric.sum_weighted_pairwise_distances(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=2.0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_weighted_maximum_mean_discrepancy_block_int(self) -> None:
-        r"""
-        Test the weighted_maximum_mean_discrepancy_block computations.
-
-        For
-        .. math::
-
-            reference_data = [[0,0], [1,1], [2,2]],
-
-            comparison_data = [[0,0], [1,1]],
-
-            w_1^T = [0.5, 0.5, 0],
-
-            w_2^T = [1, 0],
-
-        the weighted maximum mean discrepancy is given by:
-
-        .. math::
-
-            \text{WMMD}^2(\mathcal{D}_1, \mathcal{D}_2) =
-            w_1^T k(\mathcal{D}_1, \mathcal{D}_1) w_1
-            + w_2^T k(\mathcal{D}_2, \mathcal{D}_2) w_2
-            - 2 w_1^T k(\mathcal{D}_1, \mathcal{D}_2) w_2
-
-        which, when :math:`k(\mathcal{D}_1,\mathcal{D}_2)` is the RBF kernel,
-        reduces to:
-
-        .. math::
-
-            \frac{1}{2} + \frac{e^{-1}}{2} + 1 - 2\times(\frac{1}{2} + \frac{e^{-1}}{2})
-
-            = \frac{1}{2} - \frac{e^{-1}}{2}.
-        """
-        # Define some data
-        reference_points = jnp.array([[0, 0], [1, 1], [2, 2]])
-        comparison_points = jnp.array([[0, 0], [1, 1]])
-        reference_weights = jnp.array([0.5, 0.5, 0])
-        comparison_weights = jnp.array([1, 0])
-
-        # Define expected output
-        expected_output = jnp.sqrt(1 / 2 - jnp.exp(-1) / 2)
-
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute weighted MMD block-wise
-        output = metric.weighted_maximum_mean_discrepancy_block(
-            reference_points=reference_points,
-            comparison_points=comparison_points,
-            reference_weights=reference_weights,
-            comparison_weights=comparison_weights,
-            block_size=2,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(float(output), float(expected_output), places=5)
-
-    def test_weighted_maximum_mean_discrepancy_block_equals_mmd(self) -> None:
-        r"""
-        Test weighted MMD computations with uniform weights.
-
-        One expects that, when weights are uniform the output of
-        weighted_maximum_mean_discrepancy_block should be the same as an unweighted
-        computation.
-        """
-        # Define a kernel object
-        length_scale = 1.0
-        kernel = coreax.kernel.SquaredExponentialKernel(length_scale=length_scale)
-
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=kernel)
-
-        # Compute weighted MMD with uniform weights
-        output = metric.weighted_maximum_mean_discrepancy_block(
-            self.reference_points,
-            self.comparison_points,
-            reference_weights=jnp.ones(self.num_reference_points)
-            / self.num_reference_points,
-            comparison_weights=jnp.ones(self.num_comparison_points)
-            / self.num_comparison_points,
-            block_size=self.block_size,
-        )
-
-        # Check output matches expected
-        self.assertAlmostEqual(
-            float(output),
-            float(
-                metric.maximum_mean_discrepancy(
-                    self.reference_points, self.comparison_points
-                )
-            ),
-            places=5,
-        )
-
-    def test_weighted_maximum_mean_discrepancy_block_zero_block_size(self) -> None:
-        """
-        Test weighted_maximum_mean_discrepancy_block when given a zero block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute weighted MMD with a zero block_size - this should error as we require
-        # a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.weighted_maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_weighted_maximum_mean_discrepancy_block_negative_block_size(self) -> None:
-        """
-        Test weighted_maximum_mean_discrepancy_block when given a negative block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute weighted MMD with a negative block_size - this should raise an error
-        # highlighting that block_size should be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.weighted_maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=-2,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_weighted_maximum_mean_discrepancy_block_float_block_size(self) -> None:
-        """
-        Test weighted_maximum_mean_discrepancy_block when given a float block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute weighted MMD with a float block_size - this should raise an error
-        # explaining this parameter must be a positive integer
-        with self.assertRaises(TypeError) as error_raised:
-            metric.weighted_maximum_mean_discrepancy_block(
-                reference_points=self.reference_points,
-                comparison_points=self.comparison_points,
-                reference_weights=self.reference_weights,
-                comparison_weights=self.comparison_weights,
-                block_size=2.0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_compute_zero_block_size(self) -> None:
-        """
-        Test compute when given a zero block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a zero block_size - this should raise an error explaining
-        # this parameter must be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.compute(
-                reference_data=self.reference_data,
-                comparison_data=self.comparison_data,
-                block_size=0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_compute_negative_block_size(self) -> None:
-        """
-        Test compute when given a negative block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a negative block_size - this should raise an error to
-        # highlight this must be a positive integer
-        with self.assertRaises(ValueError) as error_raised:
-            metric.compute(
-                reference_data=self.reference_data,
-                comparison_data=self.comparison_data,
-                block_size=-2,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-    def test_compute_float_block_size(self) -> None:
-        """
-        Test compute when given a float block size.
-        """
-        # Define a metric object
-        metric = coreax.metrics.MMD(kernel=MagicMock())
-
-        # Compute MMD with a float block_size - the full text of the inbuilt error
-        # raised from the range function should provide all information needed for users
-        # to identify the issue
-        with self.assertRaises(TypeError) as error_raised:
-            metric.compute(
-                reference_data=self.reference_data,
-                comparison_data=self.comparison_data,
-                block_size=2.0,
-            )
-        self.assertEqual(
-            error_raised.exception.args[0],
-            "block_size must be a positive integer",
-        )
-
-
-# pylint: enable=too-many-public-methods
-
-
-if __name__ == "__main__":
-    unittest.main()
+        output = metric.compute(x, y)
+        assert output == pytest.approx(expected_mmd)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -210,4 +210,4 @@ class TestMMD:
         # Compute the MMD using the metric object
         metric = coreax.metrics.MMD(kernel=kernel)
         output = metric.compute(x, y)
-        assert output == pytest.approx(expected_mmd)
+        assert output == pytest.approx(expected_mmd, abs=1e-6)

--- a/tests/unit/test_reduction.py
+++ b/tests/unit/test_reduction.py
@@ -162,7 +162,7 @@ class TestCoreset(unittest.TestCase):
                 data=coreset.original_data.pre_coreset_array, weights=weights_x
             ),
             coreax.data.Data(data=coreset.coreset, weights=weights_y),
-            block_size,
+            block_size=block_size,
         )
 
     def test_refine(self):

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -86,25 +86,22 @@ class TestUtil:
         output = pairwise(difference)(x_array, y_array)
         assert jnp.linalg.norm(output - expected_output) == pytest.approx(0.0, abs=1e-3)
 
-    def test_apply_negative_precision_threshold_invalid(self) -> None:
-        """
-        Test apply_negative_precision_threshold for an invalid threshold.
-
-        A negative precision threshold is given, which should be rejected by the
-        function.
-        """
-        with pytest.raises(ValueError):
-            apply_negative_precision_threshold(x=0.1, precision_threshold=-1e-8)
-
     @pytest.mark.parametrize(
         "value, threshold, expected",
         [
             (-0.01, 0.001, -0.01),
             (-0.0001, 0.001, 0.0),
+            (-0.0001, -0.001, 0.0),
             (0.01, 0.001, 0.01),
             (0.000001, 0.001, 0.000001),
         ],
-        ids=["no_change", "with_change", "positive_input_1", "positive_input_2"],
+        ids=[
+            "no_change",
+            "with_change",
+            "negative_threshold_with_change",
+            "positive_input_1",
+            "positive_input_2",
+        ],
     )
     def test_apply_negative_precision_threshold(
         self, value: float, threshold: float, expected: float

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -21,7 +21,6 @@ import time
 from unittest.mock import Mock
 
 import jax.numpy as jnp
-import jax.tree_util as jtu
 import numpy as np
 import pytest
 from scipy.stats import ortho_group
@@ -93,12 +92,9 @@ class TestUtil:
     )
     def test_tree_leaves_repeat(self, length: int) -> None:
         """Test tree_leaves_repeat for various length parameters."""
-        tree = (None, 1)
-        tree_leaves = jtu.tree_leaves(tree, is_leaf=lambda x: x is None)
+        tree = [None, 1]
         repeated_tree_leaves = tree_leaves_repeat(tree, length)
-        expected_leaves = tree_leaves + [
-            1,
-        ] * (length - len(tree))
+        expected_leaves = tree + [1] * (length - len(tree))
         assert repeated_tree_leaves == expected_leaves
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Type
Closes #613 

- Refactoring (no functional changes)
- Documentation content changes
- Tests

### Description
Significantly reduces duplication from `coreax.metrics` by using the new `kernel.compute_mean` method. This also allows many of the tests from `test_metrics.py` to be removed as the associated functionality is already tested, for `kernel.compute_mean`, in `test_kernels.py`

Additionaly converts `coreax.util.apply_negative_precision_threshold` to be JIT compatible (allowing `metric.compute` to be JIT compiled).
 
### How Has This Been Tested?
All tests pass

### Does this PR introduce a breaking change?
All methods except for `compute` have been removed from `coreax.mdd.MMD`.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
