### PR TITLE
feat(CI): replace most pygrep hooks with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,13 +85,6 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      # Prevent common mistakes of `assert mck.not_called()`,
-      # `assert mck.called_once_with(...)` and `mck.assert_called`
-      - id: python-check-mock-methods
-      # Check for the `eval()` built-in function - necessary for security
-      - id: python-no-eval
-      # Check for the deprecated `.warn()` method of Python loggers
-      - id: python-no-log-warn
       # Enforce that type annotations are used instead of type comments
       - id: python-use-type-annotations
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,15 +84,19 @@ src = [".", "examples"]
 [tool.ruff.lint]
 preview = true
 select = [
-    "B",   # flake8-bugbear
-    "C90", # McCabe
-    "D",   # pydocstyle
-    "E",   # pycodestyle [error]
-    "F",   # pyflakes
-    "I",   # isort
-    "N",   # pep8-naming
-    "PL",  # pylint
-    "W",   # pycodestyle [warning]
+    "B",      # flake8-bugbear
+    "C90",    # McCabe
+    "D",      # pydocstyle
+    "E",      # pycodestyle [error]
+    "F",      # pyflakes
+    "G010",   # logging-warn
+    "I",      # isort
+    "N",      # pep8-naming
+    "PGH005", # invalid-mock-access
+    "PL",     # pylint
+    "S102",   # exec-builtin
+    "S307",   # suspicious-eval-usage
+    "W",      # pycodestyle [warning]
 ]
 
 ignore = [
@@ -122,7 +126,7 @@ ignore-init-module-imports = true
 [tool.ruff.lint.pylint]
 max-args = 10
 max-locals = 20
-allow-dunder-method-names = ["__check_init__"]
+allow-dunder-method-names = ["__check_init__", "__jax_array__"]
 
 [tool.coverage.run]
 command_line = "-m pytest tests/unit --cov"


### PR DESCRIPTION
Closes: #597

### PR Type
- CI related changes

### Description
Replaces most pygrep hooks with ruff.

Only `use-type-annotations` is retained; ruff only supports this check for PYI files (PYI033).

### How Has This Been Tested?
CI runs as expected.

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
