### PR TITLE
Fix/approximate data compatibility

### DIFF
--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -183,7 +183,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.asarray(x)
+        data = jnp.atleast_2d(jnp.asarray(x))
         num_data_points = len(data)
         key = self.random_key
         features_idx = _random_indices(key, num_data_points, self.num_kernel_points - 1)
@@ -223,7 +223,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.asarray(x)
+        data = jnp.atleast_2d(jnp.asarray(x))
         num_data_points = len(data)
         features = jnp.zeros((num_data_points, self.num_kernel_points))
         features = features.at[:, 0].set(self.base_kernel.compute(data, data[0])[:, 0])
@@ -279,7 +279,7 @@ class NystromApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.asarray(x)
+        data = jnp.atleast_2d(jnp.asarray(x))
         num_data_points = len(data)
         feature_idx = _random_indices(
             self.random_key, num_data_points, self.num_kernel_points

--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -27,10 +27,9 @@ all functionality provided through composition with a ``base_kernel``, they can 
 freely used in any place where a standard :class:`~coreax.kernel.Kernel` is expected.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from functools import partial
+from typing import Union
 
 import jax
 import jax.numpy as jnp
@@ -173,7 +172,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
+    def gramian_row_mean(self, x: Union[ArrayLike, Data], **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by Monte-Carlo sampling.
 
@@ -212,7 +211,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
+    def gramian_row_mean(self, x: Union[ArrayLike, Data], **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by random regression on ANNchor points.
 
@@ -267,7 +266,7 @@ class NystromApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
+    def gramian_row_mean(self, x: Union[ArrayLike, Data], **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by Nystrom approximation.
 

--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -27,7 +27,10 @@ all functionality provided through composition with a ``base_kernel``, they can 
 freely used in any place where a standard :class:`~coreax.kernel.Kernel` is expected.
 """
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -36,6 +39,7 @@ from jax import Array
 from jax.typing import ArrayLike
 from typing_extensions import TYPE_CHECKING, Literal, override
 
+from coreax.data import Data
 from coreax.kernel import CompositeKernel
 from coreax.util import KeyArrayLike
 
@@ -169,7 +173,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
+    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by Monte-Carlo sampling.
 
@@ -180,7 +184,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.atleast_2d(x)
+        data = jnp.asarray(x)
         num_data_points = len(data)
         key = self.random_key
         features_idx = _random_indices(key, num_data_points, self.num_kernel_points - 1)
@@ -190,7 +194,7 @@ class MonteCarloApproximateKernel(RandomRegressionKernel):
             data,
             features,
             self.num_train_points,
-            lambda x: self.base_kernel.compute(x, data).sum(axis=1) / num_data_points,
+            partial(self.base_kernel.compute_mean, data, axis=0),
         )
 
 
@@ -208,7 +212,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
+    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by random regression on ANNchor points.
 
@@ -220,7 +224,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.atleast_2d(x)
+        data = jnp.asarray(x)
         num_data_points = len(data)
         features = jnp.zeros((num_data_points, self.num_kernel_points))
         features = features.at[:, 0].set(self.base_kernel.compute(data, data[0])[:, 0])
@@ -245,7 +249,7 @@ class ANNchorApproximateKernel(RandomRegressionKernel):
             data,
             features,
             self.num_train_points,
-            lambda x: self.base_kernel.compute(x, data).mean(axis=1),
+            partial(self.base_kernel.compute_mean, data, axis=0),
         )
 
 
@@ -263,7 +267,7 @@ class NystromApproximateKernel(RandomRegressionKernel):
     :param num_train_points: Number of training points used to fit kernel regression
     """
 
-    def gramian_row_mean(self, x: ArrayLike, **kwargs) -> Array:
+    def gramian_row_mean(self, x: ArrayLike | Data, **kwargs) -> Array:
         r"""
         Approximate the Gramian row-mean by Nystrom approximation.
 
@@ -276,7 +280,7 @@ class NystromApproximateKernel(RandomRegressionKernel):
         :return: Approximation of the base kernel's Gramian row-mean
         """
         del kwargs
-        data = jnp.atleast_2d(x)
+        data = jnp.asarray(x)
         num_data_points = len(data)
         feature_idx = _random_indices(
             self.random_key, num_data_points, self.num_kernel_points
@@ -287,5 +291,5 @@ class NystromApproximateKernel(RandomRegressionKernel):
             data,
             features,
             self.num_train_points,
-            lambda x: self.base_kernel.compute(x, x).sum(axis=1) / num_data_points,
+            self.base_kernel.gramian_row_mean,
         )

--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -8,15 +8,9 @@ import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Shaped
 
-from coreax.data import Data
+from coreax.data import Data, as_data
 
 _Data = TypeVar("_Data", bound=Data)
-
-
-def _convert_to_weighted(data: Data | Array):
-    if isinstance(data, Data):
-        return data
-    return Data(data)
 
 
 class Coreset(eqx.Module, Generic[_Data]):
@@ -61,7 +55,7 @@ class Coreset(eqx.Module, Generic[_Data]):
     :param pre_coreset_data: The dataset :math:`X` used to construct the coreset.
     """
 
-    nodes: Data = eqx.field(converter=_convert_to_weighted)
+    nodes: Data = eqx.field(converter=as_data)
     pre_coreset_data: _Data
 
     def __len__(self):

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -207,18 +207,22 @@ class Data(eqx.Module):
         the ones vector (implies a scalar weight of one);
     """
 
-    data: Shaped[Array, " n d"]
+    data: Shaped[Array, " n *d"]
     weights: Shaped[Array, " n"]
 
     def __init__(
         self,
-        data: Shaped[ArrayLike, " n d"],
+        data: Shaped[ArrayLike, " n *d"],
         weights: Shaped[ArrayLike, " n"] | None = None,
     ):
         """Initialise Data class."""
-        self.data = jnp.atleast_2d(data)
-        n = self.data.shape[0]
+        self.data = jnp.asarray(data)
+        n = self.data.shape[:1]
         self.weights = jnp.broadcast_to(1 if weights is None else weights, n)
+
+    def __jax_array__(self) -> Shaped[ArrayLike, " n d"]:
+        """Register ArrayLike behaviour - return value for `jnp.asarray(Data(...))`."""
+        return self.data
 
     def __len__(self):
         """Return data length."""

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -234,8 +234,13 @@ class Data(eqx.Module):
         return eqx.tree_at(lambda x: x.weights, self, normalized_weights)
 
 
-def is_data(x: Any | Data):
-    """Return 'True' if element is an instance of 'coreax.data.Data'."""
+def as_data(x: Any) -> Data:
+    """Cast 'x' to a data instance."""
+    return x if isinstance(x, Data) else Data(x)
+
+
+def is_data(x: Any) -> bool:
+    """Return boolean indicating if 'x' is an instance of 'coreax.data.Data'."""
     return isinstance(x, Data)
 
 

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -350,7 +350,7 @@ def _block_data_convert(
     x: ArrayLike | Data, block_size: int | None
 ) -> tuple[Array, int]:
     """Convert 'x' into padded and weight normalized blocks of size 'block_size'."""
-    x = x if isinstance(x, Data) else Data(jnp.asarray(x))
+    x = x if isinstance(x, Data) else Data(x)
     x = x.normalize()
     block_size = len(x) if block_size is None else min(max(int(block_size), 1), len(x))
     unpadded_length = len(x)
@@ -367,7 +367,7 @@ def _block_data_convert(
                 raise ValueError("'x' must not be empty") from err
             raise
 
-    return jtu.tree_map(_pad_reshape, x, is_leaf=eqx.is_array_like), unpadded_length
+    return jtu.tree_map(_pad_reshape, x, is_leaf=eqx.is_array), unpadded_length
 
 
 class LinearKernel(Kernel):

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -158,6 +158,7 @@ nitpick_ignore = [
     ("py:class", "flax.core.scope.Scope"),
     ("py:class", "flax.linen.module._Sentinel"),
     ("py:class", "jaxtyping.Shaped[Array, 'n *d']"),
+    ("py:class", "jaxtyping.Shaped[ndarray, 'n *d']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n d']"),
     ("py:class", "jaxtyping.Shaped[ndarray, 'n d']"),
     ("py:class", "jaxtyping.Shaped[Array, 'n *p']"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ ignore-init-module-imports = true
 [tool.ruff.lint.pylint]
 max-args = 10
 max-locals = 20
-allow-dunder-method-names = ["__check_init__"]
+allow-dunder-method-names = ["__check_init__", "__jax_array__"]
 
 [tool.coverage.run]
 command_line = "-m pytest tests/unit --cov"

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -72,6 +72,11 @@ class TestData:
             invalid_weights = jnp.ones(DATA_ARRAY.shape[0] + 1)
             data_type(weights=invalid_weights)
 
+    def test_arraylike(self, data_type):
+        """Test interpreting data as a JAX array."""
+        _data = data_type()
+        assert eqx.tree_equal(jnp.asarray(_data), _data.data)
+
     def test_len(self, data_type):
         """Test length of data."""
         _data = data_type()

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -37,6 +37,13 @@ DATA_ARRAY = jnp.array([[1], [2], [3]])
 SUPERVISION = jnp.array([[4], [5], [6]])
 
 
+def test_as_data():
+    """Test functionality of `as_data` converter method."""
+    _array = jnp.array([1, 2, 3])
+    _data = coreax.data.Data(_array)
+    assert eqx.tree_equal(coreax.data.as_data(_array), _data)
+
+
 def test_is_data():
     """Test functionality of `is_data` filter method."""
     assert not coreax.data.is_data(123)


### PR DESCRIPTION
### PR Type

- Bugfix
- Feature

### Description
Since the introduction of `kernel.compute_mean`, the `gramian_row_mean` method is expected to accept `coreax.data.Data` objects. Compatibility is provided by making `coreax.data.Data` a proper JAX  `ArrayLike` type. This allows `Data.data` to be accessed via `jnp.asarray(Data(...))`.
    
In addition, the new `kernel.compute_mean` method allows some duplicated code to be removed from the old approximator implementations.

To reduce duplication, an `as_data` method has been added, and the `kernel.gramian_row_mean` docstring has been simplified (including typehints for block_size).

### How Has This Been Tested?
All tests pass

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
