### PR TITLE
fix: correct problem definitions in `test_weights`

### DIFF
--- a/tests/unit/test_weights.py
+++ b/tests/unit/test_weights.py
@@ -118,9 +118,10 @@ class TestSBQWeightsOptimiser(BaseWeightsOptimiserTest[_Data]):
         target_metric = MMD(kernel)
 
         pre_coreset_data = Data(jr.normal(self.random_key, self.data_shape))
-        coreset_indices = Data(jr.choice(self.random_key, self.coreset_size))
+        coreset_indices = Data(
+            jr.choice(self.random_key, self.data_shape[0], (self.coreset_size,))
+        )
         coreset = Coresubset(nodes=coreset_indices, pre_coreset_data=pre_coreset_data)
-
         return _Problem(coreset, optimiser, target_metric)
 
     def test_analytic_case(self) -> None:
@@ -195,7 +196,9 @@ class TestMMDWeightsOptimiser(BaseWeightsOptimiserTest[_Data]):
         target_metric = MMD(kernel)
 
         pre_coreset_data = Data(jr.normal(self.random_key, self.data_shape))
-        coreset_indices = Data(jr.choice(self.random_key, self.coreset_size))
+        coreset_indices = Data(
+            jr.choice(self.random_key, self.data_shape[0], (self.coreset_size,))
+        )
         coreset = Coresubset(nodes=coreset_indices, pre_coreset_data=pre_coreset_data)
 
         return _Problem(coreset, optimiser, target_metric)


### PR DESCRIPTION
### PR Type
- Bugfix
- Tests

### Description
Coreset indices were not being generated as expected; instead of a set of `self.coreset_size` indices being generated, only a single index in the range of `self.coreset_size` was generated.

This would be fine, except for `test_solver_reduces_target_metric` only being well defined for coreset sizes greater than one. When the coreset size is one, there is no guarantee that solving for the weights will reduce the target metric; the weighting is usually a relative weight against other members of the coreset.

### How Has This Been Tested?
Test pass; manual check of coreset generation in the problem now demonstrates the expected behaviour.

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
