### PR TITLE
Mandate that GPU tests to be run prior to release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ external libraries should be licensed permissive (e.g [MIT][mit]) or weak copyle
 
 ### Testing
 
-All tests are ran via the following [Pytest][pytest] command:
+All tests are run via the following [Pytest][pytest] command:
 ```bash
   pytest tests/
 ```
@@ -191,6 +191,15 @@ Use the form: (actual, expected) in asserts, e.g.
 assertEqual(actualValue, expectedValue)
 ```
 
+#### Testing before releases to PyPI
+
+Before a release is issued on PyPI, all tests for Coreax will be run on a GPU machine.
+This avoids having to incorporate GPU runners into the CI/CD.
+However, note that code pushed to `main` may not necessarily have been tested on a
+GPU machine until a release to PyPI is made.
+If you observe any issues on GPU machines using the code, please raise an issue
+detailing the behaviour, and create a PR with the relevant fix if possible.
+
 ### Abstract functions
 
 Abstract methods, functions and properties should only contain a docstring. They should
@@ -202,9 +211,9 @@ Custom exceptions should be derived from the most specific relevant Exception cl
 Custom messages should be succinct and, where easy to implement, offer suggestions to
 the user on how to rectify the exception.
 
-Avoid stating how the program will handle the error, e.g. avoid Aborting, since it will
-be evident that the program has terminated. This enables the exception to be caught and
-the program to continue in the future.
+Avoid stating how the program will handle the error, e.g. avoid `Aborting`, since it
+will be evident that the program has terminated. This enables the exception to be caught
+and the program to continue in the future.
 
 ### Docstrings
 
@@ -280,21 +289,24 @@ Releases are made on an ad-hoc basis, not on every merge into `main`. When the
 maintainers decide the codebase is ready for another release:
 
 1. Create an issue for the release.
-2. Identify a commit on `main` that is ready for release, except for housekeeping that
-   does not affect the functionality of the code.
-3. Create a branch `release/#.#.#` off the identified commit, populating with the target
+2. Run additional release tests on `main` including GPU testing, as described in
+   [Testing before releases to PyPI](#Testing-before-releases-to-PyPI).
+3. Fix any issues and merge into `main`, iterating until we have a commit on
+   `main` that is ready for release, except for housekeeping that does not affect the
+   functionality of the code.
+4. Create a branch `release/#.#.#` off the identified commit, populating with the target
    version number.
-4. Tidy `CHANGELOG.md` including:
+5. Tidy `CHANGELOG.md` including:
    - Move the content under `Unreleased` to a section under the target version number.
    - Create a new unpopulated `Unreleased` section at the top.
    - Update the hyperlinks to Git diffs at the bottom of the file so that they compare
      the relevant versions.
-5. Update the version number in `coreax/__init.py__`.
-6. Create and review a pull request.
-7. Once approved, create a release in GitHub pointing at the final commit on the release
+6. Update the version number in `coreax/__init.py__`.
+7. Create and review a pull request.
+8. Once approved, create a release in GitHub pointing at the final commit on the release
    branch.
-8. Build and publish to PyPI and ReadTheDocs.
-9. Merge the release branch into `main`.
+9. Build and publish to PyPI and ReadTheDocs.
+10. Merge the release branch into `main`.
 
 [github-issues]: https://github.com/gchq/coreax/issues?q=
 [gh-bug-report]: https://github.com/gchq/coreax/issues/new?assignees=&labels=bug%2Cnew&projects=&template=bug_report.yml&title=%5BBug%5D%3A+


### PR DESCRIPTION
closes: #771

### PR Type

- Documentation content changes

### Description

In contributor guidelines: Mandate that GPU tests to be run prior to release.

### How Has This Been Tested?

View rendered MD.

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
