### PR TITLE
docs: Clarify usage of atleast_2d from JAX inside of score matching.

### DIFF
--- a/coreax/score_matching.py
+++ b/coreax/score_matching.py
@@ -412,7 +412,13 @@ class SlicedScoreMatching(ScoreMatching):
         :param x: The :math:`n \times d` data vectors
         :return: A function that applies the learned score function to input ``x``
         """
-        # Format inputs
+        # Check format of input array. We use atleast_2d from JAX to perform
+        # conversions here. This is faster than using the custom function
+        # _atleast_2d_consistent in coreax.data, and whilst these two functions
+        # differ in output for 1-dimensional arrays, the computations inside of this
+        # function will match even in this case. This speed difference is noticeable
+        # when we use KernelDensityMatching in conjunction with a Stein kernel,
+        # where the score function may be called a huge number of times.
         x = jnp.atleast_2d(x)
 
         # Setup neural network that will approximate the score function
@@ -545,7 +551,13 @@ class KernelDensityMatching(ScoreMatching):
             :param x_: The :math:`n \times d` data vectors we wish to evaluate the score
                 function at
             """
-            # Check format
+            # Check format of input array. We use atleast_2d from JAX to perform
+            # conversions here. This is faster than using the custom function
+            # _atleast_2d_consistent in coreax.data, and whilst these two functions
+            # differ in output for 1-dimensional arrays, the computations inside of this
+            # function will match even in this case. This speed difference is noticeable
+            # when we use KernelDensityMatching in conjunction with a Stein kernel,
+            # where the score function may be called a huge number of times.
             original_number_of_dimensions = jnp.asarray(x_).ndim
             x_ = jnp.atleast_2d(x_)
 

--- a/coreax/score_matching.py
+++ b/coreax/score_matching.py
@@ -413,12 +413,9 @@ class SlicedScoreMatching(ScoreMatching):
         :return: A function that applies the learned score function to input ``x``
         """
         # Check format of input array. We use atleast_2d from JAX to perform
-        # conversions here. This is faster than using the custom function
-        # _atleast_2d_consistent in coreax.data, and whilst these two functions
-        # differ in output for 1-dimensional arrays, the computations inside of this
-        # function will match even in this case. This speed difference is noticeable
-        # when we use KernelDensityMatching in conjunction with a Stein kernel,
-        # where the score function may be called a huge number of times.
+        # conversions here which provides the desired handling of 1 dimensional arrays,
+        # whereas this handling differs if we instead used the custom function
+        # _atleast_2d_consistent in coreax.data,
         x = jnp.atleast_2d(x)
 
         # Setup neural network that will approximate the score function
@@ -552,12 +549,10 @@ class KernelDensityMatching(ScoreMatching):
                 function at
             """
             # Check format of input array. We use atleast_2d from JAX to perform
-            # conversions here. This is faster than using the custom function
-            # _atleast_2d_consistent in coreax.data, and whilst these two functions
-            # differ in output for 1-dimensional arrays, the computations inside of this
-            # function will match even in this case. This speed difference is noticeable
-            # when we use KernelDensityMatching in conjunction with a Stein kernel,
-            # where the score function may be called a huge number of times.
+            # conversions here. If we instead used the custom function
+            # _atleast_2d_consistent in coreax.data, we would require more
+            # processing when calling the methods on the kernel and the output values
+            # from these methods can differ from the expected outputs.
             original_number_of_dimensions = jnp.asarray(x_).ndim
             x_ = jnp.atleast_2d(x_)
 

--- a/coreax/score_matching.py
+++ b/coreax/score_matching.py
@@ -415,7 +415,7 @@ class SlicedScoreMatching(ScoreMatching):
         # Check format of input array. We use atleast_2d from JAX to perform
         # conversions here which provides the desired handling of 1 dimensional arrays,
         # whereas this handling differs if we instead used the custom function
-        # _atleast_2d_consistent in coreax.data,
+        # _atleast_2d_consistent in coreax.data.
         x = jnp.atleast_2d(x)
 
         # Setup neural network that will approximate the score function

--- a/tests/unit/test_score_matching.py
+++ b/tests/unit/test_score_matching.py
@@ -264,6 +264,33 @@ class TestKernelDensityMatching(unittest.TestCase):
         # Check learned score and true score align
         self.assertLessEqual(np.abs(true_score_result - score_result).mean(), 0.5)
 
+    def test_handling_of_1d_input(self) -> None:
+        """
+        Verify how the score function behaves when given a one-dimensional input.
+        """
+        data = jnp.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        matcher = KernelDensityMatching(length_scale=1)
+        score_function = matcher.match(data)
+
+        # Define data to evaluate the score function at - we consider the same
+        # data-point but given in two different shapes
+        data_1d = jnp.array([1, 2])
+        data_2d = jnp.array([[1, 2]])
+
+        # When we evaluate the score function with a 1 dimensional input, we expect the
+        # resulting score function to be 1 dimensional, which ensures compatibility with
+        # Stein kernel usage
+        np.testing.assert_array_equal(
+            score_function(data_1d), jnp.array([0.03597286, 0.03597286])
+        )
+
+        # When we evaluate the score function with a 2 dimensional input that holds a
+        # single data-point, we expect the resulting score function to be 2 dimensional,
+        # holding exactly the same values as above, but with an extra dimension
+        np.testing.assert_array_equal(
+            score_function(data_2d), jnp.array([[0.03597286, 0.03597286]])
+        )
+
 
 class TestSlicedScoreMatching(unittest.TestCase):
     """


### PR DESCRIPTION
Refs: #764

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- Documentation content changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Investigation into score matching slowdown has shown that using both JAX's `jnp.atleast_2d` and `coreax.data._atleast_2d_consistent` are consistent with desired results, but the former is faster when called a huge number of times (as is the case when one might want to use a Stein kernel). A comment has been added explaining this.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

N/A

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
