### PR TITLE
bug: Fixed issue with large batch sizes causing XLA errors in JAX 0.4.33

### DIFF
--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -223,8 +223,8 @@ class TestUtil:
         uniqueness as the probability of the converse is vanishingly small.
         """
         max_index = 1000
-        batch_size = 200
-        num_batches = 100
+        batch_size = 5
+        num_batches = 1000
         batch_indices = sample_batch_indices(
             random_key=jr.key(0),
             max_index=max_index,


### PR DESCRIPTION
Refs: #773

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

As of jax 0.4.33, XLA related errors are raised if we try to use large batch sizes of arrays in the test `test_sample_batch_indices_inter_row_uniqueness`. This test is really ensuring that, if we sample N batches of size M from K integers, then each of the N batches are unique. This is highly likely for a large K and comparatively small N, M. The pervious batch size used in the test causes issues with buffer sizes in jax 0.4.33, so I have instead kept the main purpose of the test, but altered the batch size and number of batches to avoid the buffer errors. This keeps the desired check but does not overload the JAX buffer.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Unittest passes.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
