### PR TITLE
Deprecation removals for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,10 @@ disable tqdm progress bar terminal output. Defaults to disabled (`False`).
 
 ### Removed
 
-
+- `coreax.weights.MMD` - deprecated alias for `coreax.weights.MMDWeightsOptimiser`; deprecated since version 0.2.0.
+- `coreax.weights.SBQ` - deprecated alias for `coreax.weights.SBQWeightsOptimiser`; deprecated since version 0.2.0.
+- `coreax.util.squared_distance_pairwise` - deprecated alias for `coreax.util.pairwise(squared_distance)`; deprecated since version 0.2.0.
+- `coreax.util.pairwise_difference` - deprecated alias for `coreax.util.pairwise(difference)`; deprecated since version 0.2.0.
 
 ### Deprecated
 - All uses of `coreax.kernel.Kernel` should be replaced with `coreax.kernels.base.ScalarValuedKernel`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,9 @@ or class entirely, the deprecation period must instead be at least **two minor r
 or two months (whichever is longer).**
 
 Ensure that during the deprecation period, the old behaviour still works, but raises a
-`DeprecationWarning` with an appropriate message. If at all possible, ensure that there
+`DeprecationWarning` with an appropriate message (which should include which version
+the behaviour is deprecated since, and which version the deprecated behaviour is
+expected to be removed in). If at all possible, ensure that there
 is straightforward signposting for how users should change their code to use
 non-deprecated parts of the codebase instead.
 
@@ -112,7 +114,10 @@ def my_old_function(x: int) -> int:
 def my_new_function(x: int) -> int:
     return x*4
 
-@deprecated("Renamed to my_new_function; will be removed in v0.3.0")
+@deprecated(
+    "Renamed to my_new_function."
+    + " Deprecated since v0.2.0; will be removed in v0.3.0."
+)
 def my_old_function(x: int) -> int:
     return my_new_function(x)
 

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -71,41 +71,44 @@ from coreax.kernels.scalar_valued import (
 
 # pylint:disable = abstract-method
 @deprecated(
-    "Renamed to `ScalarValuedKernel`; "
-    + " moved to `coreax.kernels.base.ScalarValuedKernel`; "
-    + " will be removed in version 0.4.0"
+    "Renamed to `ScalarValuedKernel`;"
+    + " moved to `coreax.kernels.base.ScalarValuedKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class Kernel(_ScalarValuedKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ScalarValuedKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Renamed to `UniCompositeKernel`; "
-    + " moved to `coreax.kernels.base.UniCompositeKernel`; "
-    + " will be removed in version 0.4.0"
+    "Renamed to `UniCompositeKernel`;"
+    + " moved to `coreax.kernels.base.UniCompositeKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class CompositeKernel(_UniCompositeKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.UniCompositeKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Renamed to `DuoCompositeKernel`; "
-    + " moved to `coreax.kernels.base.DuoCompositeKernel`; "
-    + " will be removed in version 0.4.0"
+    "Renamed to `DuoCompositeKernel`;"
+    + " moved to `coreax.kernels.base.DuoCompositeKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class PairedKernel(_DuoCompositeKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.DuoCompositeKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
@@ -113,142 +116,156 @@ class PairedKernel(_DuoCompositeKernel):
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.AdditiveKernel`;  will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.AdditiveKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class AdditiveKernel(_AdditiveKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.AdditiveKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.ProductKernel`;  will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.ProductKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class ProductKernel(_ProductKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ProductKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class LinearKernel(_LinearKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.LinearKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class PolynomialKernel(_PolynomialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PolynomialKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.SquaredExponentialKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.SquaredExponentialKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class SquaredExponentialKernel(_SquaredExponentialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.SquaredExponentialKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.ExponentialKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.ExponentialKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class ExponentialKernel(_ExponentialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ExponentialKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.RationalQuadraticKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.RationalQuadraticKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class RationalQuadraticKernel(_RationalQuadraticKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.RationalQuadraticKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.PeriodicKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.PeriodicKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class PeriodicKernel(_PeriodicKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PeriodicKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.LocallyPeriodicKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.LocallyPeriodicKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class LocallyPeriodicKernel(_LocallyPeriodicKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.LocallyPeriodicKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.LaplacianKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.LaplacianKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class LaplacianKernel(_LaplacianKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.SquaredExponentialKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.PCIMQKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.PCIMQKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class PCIMQKernel(_PCIMQKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PCIMQKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.scalar_valued.SteinKernel`; "
-    + " will be removed in version 0.4.0"
+    "Moved to `coreax.kernels.base.scalar_valued.SteinKernel`."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 class SteinKernel(_SteinKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PCIMQKernel`.
 
-    Will be removed in version 0.4.0
+    Deprecated since version 0.3.0. Will be removed in version 0.4.0.
     """

--- a/coreax/kernel.py
+++ b/coreax/kernel.py
@@ -73,39 +73,39 @@ from coreax.kernels.scalar_valued import (
 @deprecated(
     "Renamed to `ScalarValuedKernel`; "
     + " moved to `coreax.kernels.base.ScalarValuedKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class Kernel(_ScalarValuedKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ScalarValuedKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Renamed to `UniCompositeKernel`; "
     + " moved to `coreax.kernels.base.UniCompositeKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class CompositeKernel(_UniCompositeKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.UniCompositeKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Renamed to `DuoCompositeKernel`; "
     + " moved to `coreax.kernels.base.DuoCompositeKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class PairedKernel(_DuoCompositeKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.DuoCompositeKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
@@ -113,142 +113,142 @@ class PairedKernel(_DuoCompositeKernel):
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.AdditiveKernel`;  will be removed in version 0.3.0"
+    "Moved to `coreax.kernels.base.AdditiveKernel`;  will be removed in version 0.4.0"
 )
 class AdditiveKernel(_AdditiveKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.AdditiveKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
-    "Moved to `coreax.kernels.base.ProductKernel`;  will be removed in version 0.3.0"
+    "Moved to `coreax.kernels.base.ProductKernel`;  will be removed in version 0.4.0"
 )
 class ProductKernel(_ProductKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ProductKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class LinearKernel(_LinearKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.LinearKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.LinearKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class PolynomialKernel(_PolynomialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PolynomialKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.SquaredExponentialKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class SquaredExponentialKernel(_SquaredExponentialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.SquaredExponentialKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.ExponentialKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class ExponentialKernel(_ExponentialKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.ExponentialKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.RationalQuadraticKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class RationalQuadraticKernel(_RationalQuadraticKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.RationalQuadraticKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.PeriodicKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class PeriodicKernel(_PeriodicKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PeriodicKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.LocallyPeriodicKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class LocallyPeriodicKernel(_LocallyPeriodicKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.LocallyPeriodicKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.LaplacianKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class LaplacianKernel(_LaplacianKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.SquaredExponentialKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.PCIMQKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class PCIMQKernel(_PCIMQKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PCIMQKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """
 
 
 @deprecated(
     "Moved to `coreax.kernels.base.scalar_valued.SteinKernel`; "
-    + " will be removed in version 0.3.0"
+    + " will be removed in version 0.4.0"
 )
 class SteinKernel(_SteinKernel):
     """
     Deprecated reference to :class:`~coreax.kernels.PCIMQKernel`.
 
-    Will be removed in version 0.3.0
+    Will be removed in version 0.4.0
     """

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -237,7 +237,9 @@ def difference(
 
 
 @deprecated(
-    "Use coreax.kernels.util.median_heuristic; will be removed in version 0.4.0"
+    "Use coreax.kernels.util.median_heuristic instead."
+    + " Deprecated since version 0.3.0."
+    + " Will be removed in version 0.4.0."
 )
 @jit
 def median_heuristic(

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -219,25 +219,6 @@ def squared_distance(
     return jnp.dot(x - y, x - y)
 
 
-@deprecated(
-    "Use coreax.util.pairwise(coreax.util.squared_distance)(x, y);"
-    "will be removed in version 0.3.0"
-)
-def squared_distance_pairwise(
-    x: Union[Shaped[Array, " d"], Shaped[Array, ""], float, int],
-    y: Union[Shaped[Array, " d"], Shaped[Array, ""], float, int],
-) -> Shaped[Array, ""]:
-    r"""
-    Calculate efficient pairwise square distance between two arrays.
-
-    :param x: First set of vectors as a :math:`n \times d` array
-    :param y: Second set of vectors as a :math:`m \times d` array
-    :return: Pairwise squared distances between ``x_array`` and ``y_array`` as an
-        :math:`n \times m` array
-    """
-    return pairwise(squared_distance)(x, y)
-
-
 @jit
 def difference(
     x: Union[Shaped[Array, " d"], Shaped[Array, ""], float, int],
@@ -282,25 +263,6 @@ def median_heuristic(
     )
 
     return jnp.sqrt(median_square_distance / 2.0)
-
-
-@deprecated(
-    "Use coreax.util.pairwise(coreax.util.difference)(x, y);"
-    "will be removed in version 0.3.0"
-)
-def pairwise_difference(
-    x: Union[Shaped[Array, " d"], Shaped[Array, ""], float, int],
-    y: Union[Shaped[Array, " d"], Shaped[Array, ""], float, int],
-) -> Shaped[Array, ""]:
-    r"""
-    Calculate efficient pairwise difference between two arrays of vectors.
-
-    :param x: First set of vectors as a :math:`n \times d` array
-    :param y: Second set of vectors as a :math:`m \times d` array
-    :return: Pairwise differences between ``x_array`` and ``y_array`` as an
-        :math:`n \times m \times d` array
-    """
-    return pairwise(difference)(x, y)
 
 
 def sample_batch_indices(

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -237,7 +237,7 @@ def difference(
 
 
 @deprecated(
-    "Use coreax.kernels.util.median_heuristic; will be removed in version 0.3.0"
+    "Use coreax.kernels.util.median_heuristic; will be removed in version 0.4.0"
 )
 @jit
 def median_heuristic(

--- a/coreax/weights.py
+++ b/coreax/weights.py
@@ -39,7 +39,6 @@ import jax.numpy as jnp
 from jax import Array
 from jaxopt import OSQP
 from jaxtyping import Shaped
-from typing_extensions import deprecated
 
 from coreax.data import Data, as_data
 from coreax.kernels import ScalarValuedKernel
@@ -313,21 +312,3 @@ class MMDWeightsOptimiser(WeightsOptimiser[_Data]):
             unroll=unroll,
         )
         return solve_qp(kernel_cc, kernel_cd, **solver_kwargs)
-
-
-@deprecated("Renamed to SBQWeightsOptimiser; will be removed in version 0.3.0")
-class SBQ(SBQWeightsOptimiser):
-    """
-    Deprecated reference to :class:`~coreax.weights.SBQWeightsOptimiser`.
-
-    Will be removed in version 0.3.0
-    """
-
-
-@deprecated("Renamed to `MMDWeightsOptimiser`; will be removed in version 0.3.0")
-class MMD(MMDWeightsOptimiser):
-    """
-    Deprecated reference to :class:`~coreax.weights.MMDWeightsOptimiser`.
-
-    Will be removed in version 0.3.0
-    """


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Removals
- Documentation content changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

 - Remove items slated for deprecation in v0.3.0 (closes #578)
 - Deprecations now state what version they have been deprecated since
 - Features deprecated in v0.3.0 (`coreax.kernel`, `coreax.util.median_heuristic`) are slated for removal in v0.4.0, not v0.3.0

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

N/A

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

(Write your answer here.)

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
