### PR TITLE
Bugfix/map reduce index bug

### DIFF
--- a/examples/pounce.py
+++ b/examples/pounce.py
@@ -175,6 +175,7 @@ def main(
     plt.xlabel("Frame")
     plt.ylabel("Chosen")
     plt.tight_layout()
+    plt.show()
     if out_path is not None:
         plt.savefig(out_path / "pounce_frames.png")
     plt.close()


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Updated corax/solvers/composite.py to keep track of indices in the reduce method of the MapReduce class

### How Has This Been Tested?
<!--
    
-->

 Firstly, if you run pounce.py on the main branch, you will see that only first 10 frames are chosen, it now choses frames spread out across the all available frames. Secondly, there has been a test added in unit test that passes when just the first few datapoints are selected in a coresubset.


