### PR TITLE
fix: docstring typos and excessive test functions

### DIFF
--- a/coreax/solvers/recombination.py
+++ b/coreax/solvers/recombination.py
@@ -426,7 +426,7 @@ def _coresubset_nodes(
         compatible as the coreset size :math:`m^\prime` is unknown at compile time.
     :param is_affine_augmented: If the 'push_forward_nodes' include the :math:`\phi_1`
         affine-augmentation map.
-    :return: The coresubset nodes as defined by the 'mode.
+    :return: The coresubset nodes as defined by the 'mode'.
     """
     n, m = push_forward_nodes.shape
     m = m if is_affine_augmented else m + 1
@@ -472,7 +472,7 @@ class TreeRecombination(RecombinationSolver[Data, None]):
     equivalently expressed as :math:`\mathcal{O}(m^3)`, using the same arguments as used
     in :class:`CaratheodoryRecombination`.
 
-    ..note::
+    .. note::
         As the ratio of :math:`n / m` grows, the constant factor for the time complexity
         of :class:`TreeRecombination` increases at a logarithmic rate, rather than at a
         quadratic rate for plain :class:`CaratheodoryRecombination`. Hence, in general,
@@ -584,7 +584,7 @@ def _prepare_tree(
         (number of tree_reduction iterations required to complete tree recombination)
     """
     tree_count = tree_reduction_factor * m
-    max_tree_depth = math.ceil(math.log(n / m, tree_reduction_factor))
+    max_tree_depth = max(1, math.ceil(math.log(n / m, tree_reduction_factor)))
     padding = m * tree_reduction_factor**max_tree_depth - n
     return padding, tree_count, max_tree_depth
 


### PR DESCRIPTION
### PR Type

- Bugfix
- Documentation content changes
- Tests

### Description
Corrects minor typos in the `solvers/recombination.py` submodule. Adds
a test for all `RecombinationSolver`s, ensuring the proper behaviour of
`RecombinationSolver.reduce(dataset)`, in cases where the number of
test_functions `m` exceeds the number of nodes `n` in the input
`dataset`.

### How Has This Been Tested?
A new test has been added. All tests pass.

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
