### PR TITLE
Redirect Intersphinx inventories

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -149,7 +149,7 @@ intersphinx_mapping = {  # linking to external documentation
     "python": ("https://docs.python.org/3", None),
     "jax": ("https://jax.readthedocs.io/en/latest/", None),
     "jaxopt": ("https://jaxopt.github.io/stable/", None),
-    "flax": ("https://flax.readthedocs.io/en/latest/", None),
+    "flax": ("https://flax-linen.readthedocs.io/en/latest", None),
     "optax": ("https://optax.readthedocs.io/en/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -147,15 +147,15 @@ if RUNNING_IN_GITHUB_ACTIONS:
 # set Inter-sphinx mapping to link to external documentation
 intersphinx_mapping = {  # linking to external documentation
     "python": ("https://docs.python.org/3", None),
-    "jax": ("https://jax.readthedocs.io/en/latest/", None),
-    "jaxopt": ("https://jaxopt.github.io/stable/", None),
+    "jax": ("https://jax.readthedocs.io/en/latest", None),
+    "jaxopt": ("https://jaxopt.github.io/stable", None),
     "flax": ("https://flax-linen.readthedocs.io/en/latest", None),
-    "optax": ("https://optax.readthedocs.io/en/latest/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
-    "sklearn": ("https://scikit-learn.org/stable/", None),
-    "tqdm": ("https://tqdm.github.io/docs/", str(TQDM_CUSTOM_PATH)),
-    "equinox": ("https://docs.kidger.site/equinox/", None),
+    "optax": ("https://optax.readthedocs.io/en/latest", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+    "tqdm": ("https://tqdm.github.io/docs", str(TQDM_CUSTOM_PATH)),
+    "equinox": ("https://docs.kidger.site/equinox", None),
 }
 
 nitpick_ignore = [


### PR DESCRIPTION
closes #796 

### PR Type

- Build related changes

### Description

Update URL of flax linen (was pointing at flax NNX).

Remove trailing slashes from URLs to silence warnings about inventories having moved.

### How Has This Been Tested?

Documentation compiles.

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
