### PR TITLE
fix(ci): pass files in uv_lock_autoupdate by filename

### DIFF
--- a/.github/workflows/uv_lock_autoupdate.yml
+++ b/.github/workflows/uv_lock_autoupdate.yml
@@ -100,10 +100,10 @@ jobs:
         run: |
           export message="chore(deps): autoupdate uv.lock"
           export sha=$( git rev-parse ${{ env.update_branch }}:${{ env.lockfile_path }} )
-          export content=$( base64 -i ${{ env.lockfile_path }} )
+          base64 -i ${{ env.lockfile_path }} > $RUNNER_TEMP/base64_lockfile
           gh api --method PUT /repos/:owner/:repo/contents/${{ env.lockfile_path }} \
             --field message="$message" \
-            --field content="$content" \
+            --field content="@$RUNNER_TEMP/base64_lockfile" \
             --field branch=${{ env.update_branch }} \
             --field sha="$sha"
       - name: Commit (with signature) new requirements-doc
@@ -114,10 +114,10 @@ jobs:
         run: |
           export message="chore(deps): autoupdate requirements-doc"
           export sha=$( git rev-parse ${{ env.update_branch }}:${{ env.requirements_doc_path }} )
-          export content=$( base64 -i ${{ env.requirements_doc_path }} )
+          base64 -i ${{ env.requirements_doc_path }} > $RUNNER_TEMP/base64_requirements_doc
           gh api --method PUT /repos/:owner/:repo/contents/${{ env.requirements_doc_path }} \
             --field message="$message" \
-            --field content="$content" \
+            --field content="@$RUNNER_TEMP/base64_requirements_doc" \
             --field branch=${{ env.update_branch }} \
             --field sha="$sha"
       - name: Create or update lockfile-autoupdate pull-request


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- CI related changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Passing the (base64-encoded) contents of `uv.lock` directly on the command line results in an `Argument list too long` error. As described in the [docs](https://cli.github.com/manual/gh_api), we can instead pass `--field content="@filename"` to get `gh` to read from the file `filename`, bypassing the issue.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

I've tested this on my own fork, and it works correctly (modulo a few authentication changes I had to make to get it to run on the fork, but those shouldn't be relevant here.)

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
