### PR TITLE
Add changelog guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ Currently, we are using a [GitHub Flow][github-flow] development approach.
 - Avoid changes to unrelated files in the same commit.
 - Changes must conform to the [code](#code) guidelines.
 - Changes must have sufficient [test coverage][run-tests].
+- Ensure your changes are recorded in `CHANGELOG.md`, and ensure that the changelog
+  entry links to each issue that is closed by your PR. (When the next version is
+  released, these links will be replaced by a link to your PR.)
 - Delete your branch once it has been merged.
 
 ### Pull request process
@@ -306,6 +309,8 @@ maintainers decide the codebase is ready for another release:
    - Create a new unpopulated `Unreleased` section at the top.
    - Update the hyperlinks to Git diffs at the bottom of the file so that they compare
      the relevant versions.
+   - Replace all issue links in the new version's sections with links to the PRs that
+     closed them.
 6. Update the version number in `coreax/__init.py__`.
 7. Create and review a pull request.
 8. Once approved, create a release in GitHub pointing at the final commit on the release


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Documentation content changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Closes #828. Added instructions in CONTRIBUTING that PRs should modify the CHANGELOG and link to any issues that they close. 

I'm not 100% confident in the procedure here, but it's borne out of two aims I have for it:
 - PRs should not have to add links to themselves in the CHANGELOG, as this requires you to make the PR first and then add a separate commit to link it. (As you don't know what the PR number is until you create it!)
 - The final CHANGELOG should contain PR links, either instead of or in addition to the issue links.

Do comment if you disagree, though!

This may also want to wait for #823 to be merged, so that we can mention this in the PR template as well.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

N/A

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
