### PR TITLE
fix: rpcholesky reverts to random selection after convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added an analytical test for RPCholesky, and associated documentation in `tests.
   unit.test_solvers`.(https://github.com/gchq/coreax/pull/822)
+- Added a unit test for RPCholesky to check whether the coreset has duplicates.(https://github.com/gchq/coreax/pull/836)
 
 ### Fixed
 - `RPCholesky.reduce` in `coreax.solvers.coresubset` now computes the iteration step
   correctly.(https://github.com/gchq/coreax/pull/825)
+- `RPCholesky.reduce` in `coreax.solvers.coresubset` now does not produce duplicate
+  points in the coreset.(https://github.com/gchq/coreax/pull/836)
 
 ### Changed
 -

--- a/tests/unit/test_solvers.py
+++ b/tests/unit/test_solvers.py
@@ -1296,6 +1296,28 @@ class TestRPCholesky(ExplicitSizeSolverTest):
             solver_state.gramian_diagonal, expected_gramian_diagonal
         )
 
+    def test_rpcholesky_unique_points(self):
+        """
+        Test whether a coreset contains no duplicates when running RPCholesky.
+
+        We use a relatively large dataset (N=1_000) and set `coreset_size = N` to
+        make sure RPCholesky adds no duplicates to the coreset even after convergence.
+        """
+        shape = (1_000, 2)
+        data = Data(jr.uniform(self.random_key, shape))
+        kernel = PCIMQKernel()
+        solver = RPCholesky(
+            coreset_size=shape[0],
+            random_key=jax.random.PRNGKey(0),
+            kernel=kernel,
+            unique=True,
+        )
+
+        rpc_coreset, _ = solver.reduce(data)
+
+        coreset_indices = rpc_coreset.unweighted_indices
+        assert len(coreset_indices) == len(np.unique(coreset_indices))
+
 
 class TestSteinThinning(RefinementSolverTest, ExplicitSizeSolverTest):
     """Test cases for :class:`coreax.solvers.coresubset.SteinThinning`."""


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Make sure RPCholesky outputs a full coreset of `coreset_size` by falling back on random selection. Resolves #835.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- Tests pass
- No repeating points in the coreset, even if `coreset_size == num_data_points`. 
- The initial points before convergence coincide before and after the fix.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
