### PR TITLE
fix: include coreax sub-packages in setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,11 @@ Issues = "https://github.com/gchq/coreax/issues"
 Changelog = "https://github.com/gchq/coreax/blob/main/CHANGELOG.md"
 
 [tool.setuptools]
-packages = ["coreax"]
+packages = [
+    "coreax",
+    "coreax.kernels",
+    "coreax.solvers",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "coreax.__version__"}


### PR DESCRIPTION
closes: #843

### PR Type

- Build related changes

### Description

Explicitly include Coreax subpackages in setuptools section of pyproject.toml.

### How Has This Been Tested?

Build includes all files in subpackages.

### Does this PR introduce a breaking change?

No

### Screenshots


### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
