### PR TITLE
fix: mmd metric returning nan

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -74,6 +74,8 @@ meshgrid
 mimread
 mimsave
 minval
+MMD
+mmd
 modindex
 myst
 nabla

--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -74,7 +74,6 @@ meshgrid
 mimread
 mimsave
 minval
-MMD
 mmd
 modindex
 myst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- `MMD.compute` no longer returns `nan`. (https://github.com/gchq/coreax/issues/855)
 
 ### Changed
 


### PR DESCRIPTION
`MMD^2` in the computation has been truncated to ensure it is non-negative.

### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Bugfix

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->

`MMD.compute` has been changed so that it returns 0 if precision error causes it to be negative.

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

The previous known case returns 0 instead of nan. 

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
