### PR TITLE
fix: numerical errors in GPU recombination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MMD.compute` no longer returns `nan`. (https://github.com/gchq/coreax/issues/855)
 - CaratheodoryRecombination now generates correct coresets on GPU machines
-  (https://github.com/gchq/coreax/issues/853)
+  (https://github.com/gchq/coreax/pull/874)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `MMD.compute` no longer returns `nan`. (https://github.com/gchq/coreax/issues/855)
+- CaratheodoryRecombination now generates correct coresets on GPU machines
+  (https://github.com/gchq/coreax/issues/853)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `MMD.compute` no longer returns `nan`. (https://github.com/gchq/coreax/issues/855)
-- CaratheodoryRecombination now generates correct coresets on GPU machines
-  (https://github.com/gchq/coreax/pull/874)
+- Corrected an implementation error in `coreax.solvers.CaratheodoryRecombination`
+  which caused numerical instability when using either `CaratheodoryRecombination`
+  or `TreeRecombination` on GPU machines. (https://github.com/gchq/coreax/pull/874, see
+  also https://github.com/gchq/coreax/issues/852 and
+  https://github.com/gchq/coreax/issues/853)
 
 ### Changed
 

--- a/coreax/solvers/recombination.py
+++ b/coreax/solvers/recombination.py
@@ -248,7 +248,7 @@ class CaratheodoryRecombination(RecombinationSolver[Data, None]):
                 basis_vector > 0, _weights / basis_vector, jnp.inf
             )
             elimination_index = jnp.argmin(elimination_condition)
-            eliminated = eliminated.at[elimination_index].set(1)
+            eliminated = eliminated.at[elimination_index].set(True)
             elimination_rescaling_factor = elimination_condition[elimination_index]
             # Equation 4: Eliminate the selected weight and redistribute its mass.
             # NOTE: Equation 5 is implicit from Equation 4 and is performed outside


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Bugfix

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->

Closes #852. Closes #853. Fixes an incorrect update applied in the elimination step of the recombination solvers.

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

Existing tests pass as expected, even on a GPU machine.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
