### PR TITLE
Export coverage and performance data to metadata repo instead of gist

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -106,15 +106,18 @@ jobs:
           export content=$( base64 -i $RUNNER_TEMP/badge.json )
           # Create new file if does not exist yet (or did not exist at checkout)
           if [ ! -f $BADGE_PATH ]; then
-            gh api --method PUT repos/:owner/coreax-metadata/contents/$BADGE_PATH \
+            gh api --method PUT /repos/:owner/coreax-metadata/contents/$BADGE_PATH \
               -f message="$message" \
               -f content="$content"
             if [ $? -eq 0 ]; then
               echo "Coverage badge created."
               exit 0
             fi
+            # Failed to create, probably because a file of this name now exists, so
+            # continue
           fi
-          # Update existing file, trying 3 times
+          # Update existing file, trying 3 times in case another job updates the
+          # coverage badge almost concurrently, which invalidates old SHA
           for i in {1..3}; do
             # Check whether file has changed
             diff $BADGE_PATH $RUNNER_TEMP/badge.json
@@ -122,9 +125,9 @@ jobs:
               echo "Coverage badge unchanged."
               exit 0
             fi
-            # Changed: replace existing file, trying 3 times
+            # Changed: replace existing file
             export sha=$( git rev-parse main:$BADGE_PATH )
-            gh api --method PUT $BADGE_PATH \
+            gh api --method PUT /repos/:owner/coreax-metadata/contents/$BADGE_PATH \
               -f message="$message" \
               -f content="$content" \
               -f sha="$sha"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,17 +56,24 @@ jobs:
   coverage-badge:
     name: Update coverage badge
     if: github.event_name == 'push'
-    # Push coverage badge config to a GitHub Gist. The Gist can currently only be hosted
-    # by a user rather than an organisation. A PAT with write Gist permissions needs to
-    # be saved as a secret of this repo. The PAT and Gist ID need updating if the host
-    # user changes.
+    # Push coverage badge config to coreax-metadata repo.
     needs:
       - coverage
     env:
       percentage: ${{ needs.coverage.outputs.percentage }}
-      GITHUB_TOKEN: ${{ secrets.COVERAGE_GIST_KEY }}
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
+          private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}
+          repositories: coreax-metadata
+      - name: Check out metadata repo
+        uses: actions/checkout@v4
+        with:
+          repository: gchq/coreax-metadata
       - name: Choose badge colour
         id: design
         run: |
@@ -87,9 +94,46 @@ jobs:
             echo "  \"message\": \"${{ env.percentage }}%\","
             echo "  \"color\": \"${{ steps.design.outputs.colour }}\""
             echo "}"
-          } > badge.json
-      - name: Write Gist
+          } > $RUNNER_TEMP/badge.json
+      - name: Commit badge (with signature)
+        # If another workflow is running in parallel, a race condition may occur. Try to
+        # push the updated badge three times before failing.
         env:
-          gist_id: 51dd332be75961a7dc903c67718028e1
-          out_name: coreax_coverage.json
-        run: gh gist edit ${{ env.gist_id }} -a ${{ env.out_name }} badge.json
+          BADGE_PATH: coverage/coreax_coverage.json
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          export message="chore: update coverage for $GITHUB_SHA"
+          export content=$( base64 -i $RUNNER_TEMP/badge.json )
+          # Create new file if does not exist yet (or did not exist at checkout)
+          if [ ! -f $BADGE_PATH ]; then
+            gh api --method PUT repos/:owner/coreax-metadata/contents/$BADGE_PATH \
+              -f message="$message" \
+              -f content="$content"
+            if [ $? -eq 0 ]; then
+              echo "Coverage badge created."
+              exit 0
+            fi
+          fi
+          # Update existing file, trying 3 times
+          for i in {1..3}; do
+            # Check whether file has changed
+            diff $BADGE_PATH $RUNNER_TEMP/badge.json
+            if [ $? -eq 0 ]; then
+              echo "Coverage badge unchanged."
+              exit 0
+            fi
+            # Changed: replace existing file, trying 3 times
+            export sha=$( git rev-parse main:$BADGE_PATH )
+            gh api --method PUT $BADGE_PATH \
+              -f message="$message" \
+              -f content="$content" \
+              -f sha="$sha"
+            if [ $? -eq 0 ]; then
+              echo "Coverage badge updated."
+              exit 0
+            fi
+            # Failed: remote has probably updated, so pull latest again
+            git pull
+          done
+          echo "Failed to update coverage badge after 3 attempts."
+          exit 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv run pytest tests/unit --cov
       - name: Extract total coverage percentage
         id: cov
-        run: echo "percentage=$( coverage report --format=total )" >> $GITHUB_OUTPUT
+        run: echo "percentage=$( uv run coverage report --format=total )" >> $GITHUB_OUTPUT
       - name: Minimize UV cache
         run: uv cache prune --ci
         if: always()

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,9 +13,6 @@ jobs:
   performance-check:
     name: Check performance
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      gist_id: 3707a122b3697109068a3e55487de4fc
     steps:
       - uses: actions/checkout@v4
       - name: Set up base Python
@@ -50,16 +47,23 @@ jobs:
         run: uv run tests/performance/run.py --output-file $RUNNER_TEMP/performance.json
       - name: Download historic performance data
         if: github.event_name == 'pull_request'
-        run: gh gist clone ${{ env.gist_id }} $RUNNER_TEMP/historic
+        uses: actions/checkout@v4
+        with:
+          repository: gchq/coreax-metadata
+          path: tmp_coreax-metadata
       - name: Compare performance against historic data
         if: github.event_name == 'pull_request'
+        env:
+          HISTORIC: tmp_coreax-metadata/performance
         run: |
           # save the commit subject to a file in case it contains any shell
           # special characters
           git log -1 --pretty=%s > $RUNNER_TEMP/commit_subject.txt
+          # Create directory if it doesn't exist yet
+          mkdir -p $HISTORIC
           uv run tests/performance/compare.py \
             $RUNNER_TEMP/performance.json \
-            $RUNNER_TEMP/historic \
+            $HISTORIC \
             --commit-short-hash $(git log -1 --pretty=%h) \
             --commit-subject-file $RUNNER_TEMP/commit_subject.txt \
             > $RUNNER_TEMP/comment.md
@@ -77,14 +81,26 @@ jobs:
               repo: context.repo.repo,
               body: fs.readFileSync(`${RUNNER_TEMP}/comment.md`, "utf8")
             })
+      - name: Generate a token for saving performance data
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
+          private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}
+          repositories: coreax-metadata
       - name: Save performance data to Gist
         if: github.event_name == 'push'
         env:
           # this is the only step that should actually need write permissions
-          GITHUB_TOKEN: ${{ secrets.COVERAGE_GIST_KEY }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          OUT_NAME="performance-$(date --utc +%Y-%m-%d--%H-%M-%S)--$GITHUB_SHA--v1.json"
-          gh gist edit ${{ env.gist_id }} -a $OUT_NAME $RUNNER_TEMP/performance.json
+          export message="chore: update performance for $GITHUB_SHA"
+          export content=$( base64 -i $RUNNER_TEMP/performance.json )
+          OUT_NAME="performance/performance-$(date --utc +%Y-%m-%d--%H-%M-%S)--$GITHUB_SHA--v1.json"
+          gh api --method PUT \
+            /repos/:owner/coreax-metadata/contents/$OUT_NAME \
+            -f message="$message" \
+            -f content="$content"
       - name: Minimize UV cache
         run: uv cache prune --ci
         if: always()

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -50,6 +50,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gchq/coreax-metadata
+          # GitHub Actions require check out destination to be within coreax/coreax. To
+          # save checking out the main repo into coreax/coreax/coreax, check out the
+          # metadata repo to a nested location inside coreax/coreax. Pick a folder name
+          # that is very unlikely to clash with any current or future folder name
+          # committed to the main coreax repo.
           path: tmp_coreax-metadata
       - name: Compare performance against historic data
         if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Moved coverage and performance data from GitHub gist to coreax-metadata repo.
+  (https://github.com/gchq/coreax/pull/887)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Coreax
 
 [![Unit Tests](https://github.com/gchq/coreax/actions/workflows/unittests.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/unittests.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Ftp832944%2F51dd332be75961a7dc903c67718028e1%2Fraw%2Fcoreax_coverage.json)](https://github.com/gchq/coreax/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgchq%2Fcoreax-metadata%2Frefs%2Fheads%2Fmain%2Fcoverage%2Fcoreax_coverage.json)](https://github.com/gchq/coreax/actions/workflows/coverage.yml)
 [![Pre-commit Checks](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml/badge.svg)](https://github.com/gchq/coreax/actions/workflows/pre_commit_checks.yml)
 [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![Python version](https://img.shields.io/pypi/pyversions/coreax.svg)](https://pypi.org/project/coreax)

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -13,7 +13,7 @@ cachecontrol==0.14.1
 certifi==2024.8.30
 charset-normalizer==3.4.0
 chex==0.1.87
-colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows'
+colorama==0.4.6 ; platform_system == 'Windows' or sys_platform == 'win32'
 cssutils==2.11.1
 dict2css==0.3.0.post1
 docutils==0.21.2


### PR DESCRIPTION
### PR Type

- CI related changes

### Description

Change coverage and performance workflows to direct output to coreax-metadata repo. Redirect coverage badge to read from this new location.

Fix coverage export to run under uv - was command not found.

Please also review the commits in coreax-metadata repo. https://github.com/[gchq/coreax-metadata](https://github.com/gchq/coreax-metadata)

Complexity: 5

**Leave the merge to the author. Data needs to be copied from the Gist to the metadata repo, which I won't do until this PR is ready and approved.**

### How Has This Been Tested?

- Temporarily adjust workflow to push coverage badge as part of PR CI. (I have squashed these commits - sorry!)

### Does this PR introduce a breaking change?

Yes to supporting infrastructure.

- Coverage badge endpoint is now at https://raw.githubusercontent.com/gchq/coreax-metadata/refs/heads/main/coverage/coreax_coverage.json.


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
