### PR TITLE
Pylint pre-commit should not run in parallel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,7 +121,7 @@ repos:
         name: pylint
         entry: pylint
         language: system
-        require_serial: true  # ensure only on Pylint process is used
+        require_serial: true  # ensure only one Pylint process is used
         types:
           - python
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,7 @@ repos:
         name: pylint
         entry: pylint
         language: system
+        require_serial: true  # ensure only on Pylint process is used
         types:
           - python
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also https://github.com/gchq/coreax/issues/852 and
   https://github.com/gchq/coreax/issues/853)
 - `KernelHerding.refine` correctly computes a refinement of an existing coreset. (https://github.com/gchq/coreax/issues/870)
+- Pylint pre-commit hook is now configured as the Pylint docs recommend (https://github.com/gchq/coreax/pull/899)
 
 ### Changed
 

--- a/tests/coverage/compare.py
+++ b/tests/coverage/compare.py
@@ -22,6 +22,9 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+# A good amount of this code is duplicated in the performance comparison script, but we
+# ignore this so that both scripts can be standalone.
+# pylint: disable=duplicate-code
 COVERAGE_FILENAME_REGEX = re.compile(
     r"^coverage"
     r"-(\d{4})-(\d{2})-(\d{2})"
@@ -187,3 +190,4 @@ def main() -> None:  # noqa: C901
 
 if __name__ == "__main__":
     main()
+# pylint: enable=duplicate-code

--- a/tests/performance/compare.py
+++ b/tests/performance/compare.py
@@ -26,6 +26,10 @@ from typing_extensions import TypedDict
 
 from coreax.util import format_time
 
+# A good amount of this code is duplicated in the coverage comparison script, but we
+# ignore this so that both scripts can be standalone.
+# pylint: disable=duplicate-code
+
 PERFORMANCE_FILENAME_REGEX = re.compile(
     r"^performance"
     r"-(\d{4})-(\d{2})-(\d{2})"
@@ -357,3 +361,5 @@ def get_significant_differences(
 
 if __name__ == "__main__":
     main()
+
+# pylint: enable=duplicate-code


### PR DESCRIPTION


### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Bugfix
- CI related changes

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->
The Pylint docs recommend against using Pylint as a pre-commit hook in the first place, but that if you do need to set `require_serial` to `true`. Otherwise, it might give inconsistent results on some checkers (such as `duplicate-code`) since the files that contain duplicate code might be analysed by two separate Pylint processes.

See: https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

Pre-commit still runs as expected; testing the effects directly is not easy but this should avoid inconsistent results on certain checkers.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
