### PR TITLE
fix: correct sign of periodic kernel expected gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pylint pre-commit hook is now configured as the Pylint docs recommend. (https://github.com/gchq/coreax/pull/899)
 - Type annotations so that core coreax package passes Pyright. (https://github.com/gchq/coreax/pull/906)
 - Type annotations so that the example scripts pass Pyright. (https://github.com/gchq/coreax/pull/921)
+- Incorrectly-implemented tests for the gradients of `PeriodicKernel`. (https://github.com/gchq/coreax/pull/936)
 
 ### Changed
 

--- a/tests/unit/test_kernels.py
+++ b/tests/unit/test_kernels.py
@@ -1971,7 +1971,7 @@ class TestPeriodicKernel(
         )
         return _Problem(x, y, expected_distances, modified_kernel)
 
-    def expected_grad_x(
+    def expected_grad_y(
         self, x: ArrayLike, y: ArrayLike, kernel: PeriodicKernel
     ) -> np.ndarray:
         x = np.atleast_2d(x)
@@ -1998,10 +1998,10 @@ class TestPeriodicKernel(
                 )
         return expected_gradients
 
-    def expected_grad_y(
+    def expected_grad_x(
         self, x: ArrayLike, y: ArrayLike, kernel: PeriodicKernel
     ) -> np.ndarray:
-        return -self.expected_grad_x(x, y, kernel)
+        return -self.expected_grad_y(x, y, kernel)
 
     def expected_divergence_x_grad_y(
         self, x: ArrayLike, y: ArrayLike, kernel: PeriodicKernel


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Bugfix

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->

In current `main`, the sign of the expected gradient for the `PeriodicKernel` is incorrect. However, this wasn't showing up in tests, since it was also evaluating to 0. On Jax 0.5.0, it was no longer evaluating to zero, and so started causing test failures. (See #930;  this PR doesn't fix all the issues there.)

We should probably investigate why the gradient was evaluating to 0, and why it isn't doing so in jax 0.5.0!

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

The `grad_x` and `grad_y` tests pass with jax 0.5.0. Also, the definitions now match between `TestPeriodicKernel` and `PeriodicKernel`.

### Does this PR introduce a breaking change?
No.


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
