### PR TITLE
fix: stacklevel of MapReduce padding warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type annotations so that the example scripts pass Pyright. (https://github.com/gchq/coreax/pull/921)
 - `KernelThinning` now computes swap probability correctly. (https://github.com/gchq/coreax/pull/932)
 - Incorrectly-implemented tests for the gradients of `PeriodicKernel`. (https://github.com/gchq/coreax/pull/936)
+- `MapReduce`'s warning about a solver not being padding-invariant is now raised at the
+  correct stack level. (https://github.com/gchq/coreax/pull/951)
 
 ### Changed
 

--- a/coreax/solvers/composite.py
+++ b/coreax/solvers/composite.py
@@ -118,7 +118,9 @@ class MapReduce(
             warnings.warn(
                 "'base_solver' is not a 'PaddingInvariantSolver'; Zero-weighted padding"
                 + " applied in 'MapReduce' may lead to undefined results.",
-                stacklevel=2,
+                # __check_init__ is called inside base __init__, so stacklevel=3 should
+                # show this warning at the call site
+                stacklevel=3,
             )
 
     @override


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Bugfix

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->

MapReduce's warning about padding invariance is now raised at the correct stacklevel (so it appears at the call site, rather than in the internals of Equinox.

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

Have checked the warning is raised at the call site.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->
No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
