### PR TITLE
Enable pyupgrade rules

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -116,6 +116,7 @@ pytest
 pytorch
 pytree
 pytrees
+pyupgrade
 quickstart
 rcfile
 rcond

--- a/benchmark/mnist_benchmark_visualiser.py
+++ b/benchmark/mnist_benchmark_visualiser.py
@@ -30,7 +30,7 @@ def load_benchmark_data(filename: str) -> dict:
              if there was an error loading the file.
     """
     try:
-        with open(filename, "r", encoding="utf-8") as file:
+        with open(filename, encoding="utf-8") as file:
             return json.load(file)
     except (FileNotFoundError, json.JSONDecodeError) as e:
         raise RuntimeError(f"Failed to load benchmark data: {e}") from e

--- a/coreax/approximation.py
+++ b/coreax/approximation.py
@@ -30,14 +30,14 @@ standard :class:`~coreax.kernels.ScalarValuedKernel` is expected.
 
 from collections.abc import Callable
 from functools import partial
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import jax
 import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 from jaxtyping import Shaped
-from typing_extensions import TYPE_CHECKING, Literal, override
+from typing_extensions import Literal, override
 
 from coreax.data import Data, _atleast_2d_consistent
 from coreax.kernels import UniCompositeKernel

--- a/coreax/coreset.py
+++ b/coreax/coreset.py
@@ -20,7 +20,6 @@ from typing import (
     TYPE_CHECKING,
     Final,
     Generic,
-    Tuple,
     TypeVar,
     Union,
     overload,
@@ -179,7 +178,7 @@ class PseudoCoreset(
     def build(
         cls,
         nodes: Union[Data, Array],
-        pre_coreset_data: Tuple[Array, Array],
+        pre_coreset_data: tuple[Array, Array],
     ) -> "PseudoCoreset[SupervisedData]": ...
 
     @classmethod
@@ -194,7 +193,7 @@ class PseudoCoreset(
     def build(
         cls,
         nodes: Union[Data, Array],
-        pre_coreset_data: Union[_TOriginalData, Array, Tuple[Array, Array]],
+        pre_coreset_data: Union[_TOriginalData, Array, tuple[Array, Array]],
     ) -> "PseudoCoreset[Data]\
         | PseudoCoreset[SupervisedData]\
         | PseudoCoreset[_TOriginalData]\
@@ -339,7 +338,7 @@ class Coresubset(
     def build(
         cls,
         indices: Union[Data, Array],
-        pre_coreset_data: Tuple[Array, Array],
+        pre_coreset_data: tuple[Array, Array],
     ) -> "Coresubset[SupervisedData]": ...
 
     @classmethod
@@ -354,7 +353,7 @@ class Coresubset(
     def build(
         cls,
         indices: Union[Data, Array],
-        pre_coreset_data: Union[_TOriginalData, Array, Tuple[Array, Array]],
+        pre_coreset_data: Union[_TOriginalData, Array, tuple[Array, Array]],
     ) -> "Coresubset[Data] | Coresubset[SupervisedData] | Coresubset[_TOriginalData]":
         """
         Construct a Coresubset from Data or raw Arrays.

--- a/coreax/data.py
+++ b/coreax/data.py
@@ -14,7 +14,8 @@
 
 """Data-structures for representing weighted and/or supervised data."""
 
-from typing import Optional, Sequence, Union, overload
+from collections.abc import Sequence
+from typing import Optional, Union, overload
 
 import equinox as eqx
 import jax.numpy as jnp

--- a/coreax/least_squares.py
+++ b/coreax/least_squares.py
@@ -52,7 +52,8 @@ block.
 """
 
 from abc import abstractmethod
-from typing import Any, Optional, Sequence, Union, cast
+from collections.abc import Sequence
+from typing import Any, Optional, Union, cast
 
 import equinox as eqx
 import jax

--- a/coreax/util.py
+++ b/coreax/util.py
@@ -24,17 +24,14 @@ class factories and checks for numerical precision.
 import logging
 import sys
 import time
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import partial, wraps
 from math import log10
 from typing import (
     Any,
-    Dict,
     Generic,
     NamedTuple,
     Optional,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -76,13 +73,13 @@ class JITCompilableFunction(NamedTuple):
 
     fn: Callable
     fn_args: tuple = ()
-    fn_kwargs: Optional[Dict[str, Any]] = None
-    jit_kwargs: Optional[Dict[str, Any]] = None
+    fn_kwargs: Optional[dict[str, Any]] = None
+    jit_kwargs: Optional[dict[str, Any]] = None
     name: Optional[str] = None
 
     def without_name(
         self,
-    ) -> Tuple[Callable, Tuple, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    ) -> tuple[Callable, tuple, Optional[dict[str, Any]], Optional[dict[str, Any]]]:
         """Return the tuple (fn, fn_args, fn_kwargs, jit_kwargs)."""
         return self.fn, self.fn_args, self.fn_kwargs, self.jit_kwargs
 
@@ -378,7 +375,7 @@ def speed_comparison_test(
     function_setups: Sequence[JITCompilableFunction],
     num_runs: int = 10,
     log_results: bool = False,
-    normalisation: Optional[Tuple[float, float]] = None,
+    normalisation: Optional[tuple[float, float]] = None,
 ) -> tuple[list[tuple[Array, Array]], dict[str, Array]]:
     """
     Compare compilation time and runtime of a list of JIT-able functions.

--- a/documentation/source/ref_style.py
+++ b/documentation/source/ref_style.py
@@ -22,7 +22,7 @@ Path: test/roots/test-bibliography_style_label_1/conf.py
 
 from __future__ import annotations
 
-from typing import Generator, Iterable
+from collections.abc import Generator, Iterable
 
 from pybtex.database import Entry
 from pybtex.plugin import register_plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ select = [
     "PL",     # pylint
     "S102",   # exec-builtin
     "S307",   # suspicious-eval-usage
+    "UP",     # pyupgrade
     "W",      # pycodestyle [warning]
 ]
 

--- a/tests/coverage/compare.py
+++ b/tests/coverage/compare.py
@@ -123,7 +123,7 @@ def get_most_recent_coverage_total(reference_directory: Path) -> float:
 
     most_recent_file = max(files.keys(), key=files.get)
 
-    with open(most_recent_file, "r", encoding="utf8") as f:
+    with open(most_recent_file, encoding="utf8") as f:
         coverage_dict = json.load(f)
 
     return coverage_dict["total"]

--- a/tests/performance/cases/normaliser.py
+++ b/tests/performance/cases/normaliser.py
@@ -14,8 +14,6 @@
 
 """A simple test that serves to normalise other performance test results."""
 
-from typing import Tuple
-
 from jax import (
     Array,
     numpy as jnp,
@@ -25,7 +23,7 @@ from jax import (
 from coreax.util import JITCompilableFunction
 
 
-def _setup_data() -> Tuple[Array, Array]:
+def _setup_data() -> tuple[Array, Array]:
     """Set up a large random matrix to be operated on."""
     key = jr.key(1_234)
     # big matrix to ensure high execution time

--- a/tests/performance/compare.py
+++ b/tests/performance/compare.py
@@ -19,7 +19,7 @@ import datetime
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from scipy.stats import ttest_ind_from_stats
 from typing_extensions import TypedDict
@@ -65,11 +65,11 @@ class SinglePerformanceTestData(TypedDict):
 class FullPerformanceData(TypedDict):
     """Type hint for the full performance test data file."""
 
-    results: Dict[str, SinglePerformanceTestData]
+    results: dict[str, SinglePerformanceTestData]
     normalisation: NormalisationData
 
 
-def parse_args() -> Tuple[Path, Path, str, Path]:
+def parse_args() -> tuple[Path, Path, str, Path]:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -94,7 +94,7 @@ def parse_args() -> Tuple[Path, Path, str, Path]:
     )
 
 
-def date_from_filename(path: Path) -> Optional[Tuple[datetime.datetime, str]]:
+def date_from_filename(path: Path) -> Optional[tuple[datetime.datetime, str]]:
     """
     Extract the date from a performance data file name.
 
@@ -149,7 +149,7 @@ def get_most_recent_historic_data(
     :return: Dictionary `(test_name -> dictionary(statistic -> value))` extracted from
         the most recent performance file
     """
-    files: Dict[Path, Tuple[datetime.datetime, str]] = {}
+    files: dict[Path, tuple[datetime.datetime, str]] = {}
     for filename in reference_directory.iterdir():
         date_tuple = date_from_filename(filename)
         if date_tuple is not None:
@@ -163,7 +163,7 @@ def get_most_recent_historic_data(
 
     most_recent_file = max(files.keys(), key=files.get)
 
-    with open(most_recent_file, "r", encoding="utf8") as f:
+    with open(most_recent_file, encoding="utf8") as f:
         return json.load(f)
 
 
@@ -189,13 +189,13 @@ def main() -> None:  # noqa: C901
     performance_file, reference_directory, commit_short_hash, commit_subject_file = (
         parse_args()
     )
-    with open(commit_subject_file, "r", encoding="utf8") as f:
+    with open(commit_subject_file, encoding="utf8") as f:
         # escape any underscores to avoid formatting weirdness
         commit_subject = f.read().strip().replace("_", r"\_")
 
     print(f"###### Commit `{commit_short_hash}` - _{commit_subject}_")
 
-    with open(performance_file, "r", encoding="utf8") as f:
+    with open(performance_file, encoding="utf8") as f:
         current_performance_data: dict = json.load(f)
     historic_performance_data = get_most_recent_historic_data(reference_directory)
 
@@ -270,9 +270,9 @@ def relative_change(before: float, after: float) -> float:
 
 
 def get_significant_differences(
-    current_performance: Dict[str, SinglePerformanceTestData],
-    historic_performance: Dict[str, SinglePerformanceTestData],
-) -> List[Tuple[str, List[str]]]:
+    current_performance: dict[str, SinglePerformanceTestData],
+    historic_performance: dict[str, SinglePerformanceTestData],
+) -> list[tuple[str, list[str]]]:
     """
     Check if there are any significant differences in performance.
 


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- Refactoring (no functional changes)
- CI related changes

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->
Enable Ruff's pyupgrade (UP) rules. These help automatically modernise our code (e.g. using `tuple` over `typing.Tuple`, using `{}` over `dict()`, etc.)

The only manual change made was adding "UP" to the ruff rules list - everything else is an automatic fix by Ruff.

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

Existing tests pass as expected. `ruff check` passes.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->
No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
