### PR TITLE
ci: use uv-provided hooks to keep uv.lock and requirements up-to-date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,23 @@ repos:
         args:
           - --ignore-case
           - --unique
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.6.1
+    hooks:
+      # Keep lock file up to date
+      - id: uv-lock
+      # Keep requirements-doc up to date
+      - id: uv-export
+        args: [
+          "--frozen",
+          "--quiet",
+          "--format", "requirements-txt",
+          "--no-hashes",
+          "--no-dev",
+          "--no-editable",
+          "--extra", "doc",
+          "--output-file", "requirements-doc.txt",
+        ]
   - repo: local
     hooks:
       # Check files are valid UTF-8
@@ -53,22 +70,6 @@ repos:
           (?x)^(
             examples/.+/.+.(gif|png)
           )$
-      # Keep requirements-docs.txt in sync with uv.lock
-      - id: check-requirements-docs
-        name: Keep requirements-docs.txt in sync with uv.lock
-        language: system
-        entry: >
-          uv export
-          --frozen
-          --quiet
-          --format requirements-txt
-          --no-hashes
-          --no-dev
-          --no-editable
-          --extra doc
-          --output-file requirements-doc.txt
-        pass_filenames: false
-        files: ^uv\.lock$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Delete any that do not apply.
-->

- CI related changes

### Description
<!--
    Summarise the changes and the related issue. Include relevant motivation and context. Include screenshots if useful.
-->
Adds a hook to automatically keep uv.lock up to date with pyproject.toml. Uses the uv-provided hook to keep requirements-doc.txt up-to-date, rather than running our own. 

Importantly, this means that the version of uv that we use is pinned by `.pre-commit-config.yaml`. 

### How Has This Been Tested?
<!--
    Describe the tests that you ran to verify the changes. List any relevant details for your test configuration.
-->

Pre-commit passes.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->
No.


### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
