### PR TITLE
feat: remove `SilentTQDM`.

### DIFF
--- a/coreax/util.py
+++ b/coreax/util.py
@@ -24,15 +24,13 @@ class factories and checks for numerical precision.
 import logging
 import sys
 import time
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Sequence
 from functools import partial, wraps
 from math import log10
 from typing import (
     Any,
-    Generic,
     NamedTuple,
     Optional,
-    TypeVar,
     Union,
 )
 
@@ -413,37 +411,3 @@ def speed_comparison_test(
                 )
 
     return results, timings_dict
-
-
-T = TypeVar("T")
-
-
-class SilentTQDM(Generic[T]):
-    """
-    Class implementing interface of :class:`~tqdm.tqdm` that does nothing.
-
-    It can substitute :class:`~tqdm.tqdm` to silence all output.
-
-    Based on `code by Pro Q <https://stackoverflow.com/a/77450937>`_.
-
-    Additional parameters are accepted and ignored to match interface of
-    :class:`~tqdm.tqdm`.
-
-    :param iterable: Iterable of tasks to (not) indicate progress for
-    """
-
-    def __init__(self, iterable: Iterable[T], *_args, **_kwargs):
-        """Store iterable."""
-        self.iterable = iterable
-
-    def __iter__(self) -> Iterator[T]:
-        """
-        Iterate.
-
-        :return: Next item
-        """
-        return iter(self.iterable)
-
-    @staticmethod
-    def write(*_args, **_kwargs) -> None:
-        """Do nothing instead of writing to output."""

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -187,8 +187,6 @@ nitpick_ignore = [
     ("py:class", "numpy.bool_"),
     ("py:class", "equinox._module.Module"),
     ("py:class", "coreax.coreset._Data"),
-    ("py:class", "tqdm.std.tqdm"),
-    ("py:obj", "coreax.util.T"),
     ("py:obj", "coreax.coreset._TPointsData"),
     ("py:obj", "coreax.coreset._TPointsData_co"),
     ("py:class", "coreax.coreset._TPointsData_co"),
@@ -208,7 +206,6 @@ nitpick_ignore = [
     ("py:obj", "coreax.weights._Data"),
     ("py:obj", "coreax.metrics._Data"),
     ("py:obj", "coreax.solvers.coresubset._SupervisedData"),
-    ("py:obj", "coreax.util.T"),
     ("py:class", "pathlib._local.Path"),
 ]
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -35,7 +35,6 @@ from scipy.stats import ortho_group
 
 from coreax.util import (
     JITCompilableFunction,
-    SilentTQDM,
     apply_negative_precision_threshold,
     difference,
     format_time,
@@ -346,18 +345,3 @@ class TestUtil:
         assert jnp.all(result_dict["slow_mean"].std(axis=0) == summary_stats[0][1])
         assert jnp.all(result_dict["jnp_mean"].mean(axis=0) == summary_stats[1][0])
         assert jnp.all(result_dict["jnp_mean"].std(axis=0) == summary_stats[1][1])
-
-
-class TestSilentTQDM:
-    """Test silent substitute for TQDM."""
-
-    def test_iterator(self):
-        """Test that iterator works."""
-        iterator_length = 10
-        expect = list(range(iterator_length))
-        actual = list(SilentTQDM(range(iterator_length)))
-        assert actual == expect
-
-    def test_write(self):
-        """Test that silenced version of TQDM write command does not crash."""
-        assert SilentTQDM(range(1)).write("something") is None


### PR DESCRIPTION
### PR Type
- Feature
- Refactoring (no functional changes)
- Documentation content changes
- Tests

### Description
To reduce the number of lines of code, and subsequent complexity throughout the codebase, the `SilentTQDM` class has been removed without loss of functionality.

The `SilentTQDM` functionality is now provided through a boolean `progress_bar` variable and silencing performed via the `disable` keyword argument to `tqdm.tqdm`. The `write` method is silenced by making all calls to the method conditional on the value of the `progress_bar` boolean.

### How Has This Been Tested?
Existing tests pass as expected.

### Does this PR introduce a breaking change?
`SilentTQDM` will be removed. No deprecation is required as this was an internal part of the API.
It may be good to be more explicit about what parts of the API are internal/external to enable more flexibility and allow for faster deprecation where appropriate.

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
