### PR TITLE
fix(ci): ignore ora linkcheck.

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -142,7 +142,7 @@ autodoc_default_options = {
 }
 
 if RUNNING_IN_GITHUB_ACTIONS:
-    linkcheck_ignore = ["https://stackoverflow.com"]
+    linkcheck_ignore = ["https://stackoverflow.com", "https://ora.ox.ac.uk"]
 
 # set Inter-sphinx mapping to link to external documentation
 intersphinx_mapping = {  # linking to external documentation


### PR DESCRIPTION
### PR Type
- Bugfix
- Documentation content changes

### Description
The linkcheck fails for `https://ora.ox.ac.uk` URLs when building documentation in the CI, causing the CI check to fail. In lieu of identifying a suitable workaround, it is neccessary to disable the linkchecks for these specific URLs, to correct the CI status.

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
