### PR TITLE
fix(tests): change `MapReduce` fixture scopes.

### DIFF
--- a/tests/unit/test_solvers.py
+++ b/tests/unit/test_solvers.py
@@ -2786,7 +2786,7 @@ class TestMapReduce(SolverTest):
     coreset_size: int = 16
 
     @override
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def solver_factory(self, request) -> jtu.Partial:
         del request
 
@@ -2845,13 +2845,12 @@ class TestMapReduce(SolverTest):
 
             # Allow overriding arguments
             final_args.update(**kwargs)
-
             return MapReduce(**final_args)
 
         return jtu.Partial(get_solver)
 
     @override
-    @pytest.fixture(scope="class", params=["original", "pseudo", "coresubset"])
+    @pytest.fixture(scope="function", params=["original", "pseudo", "coresubset"])
     def reduce_problem(
         self,
         request: pytest.FixtureRequest,


### PR DESCRIPTION
### PR Type
- Bugfix
- Tests

### Description
Intended as a fix to the spurious MacOS CI failures, closes #1042.

### How Has This Been Tested?
Existing tests pass as expected.

TODO: repeated re-runs of the CI

### Does this PR introduce a breaking change?
N/A


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
