### PR TITLE
fix(docs): remove link aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,10 @@ pixel image (38,700 pixels in total) to a coreset approximately 20% of this size
 (Right) 8,000 points chosen randomly.
 Run `benchmark/david_benchmark.py` to  replicate.
 
-|      Original      |      Coreset      |      Random      |
-|:------------------:|:-----------------:|:----------------:|
-| ![][DavidOriginal] | ![][DavidCoreset] | ![][DavidRandom] |
+|  Original  |  Coreset  |  Random  |
+|:----------:|:---------:|:--------:|
+| ![](https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_original.png) | ![](https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_kt.png) | ![](https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_random.png) |
 
-[DavidOriginal]: https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_original.png
-[DavidCoreset]: https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_kt.png
-[DavidRandom]: https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/data/david_random.png
 
 ### Video event detection
 
@@ -58,13 +55,9 @@ Here we identify representative frames such that most of the
 useful information in a video is preserved.
 Run `examples/pounce.py` to replicate.
 
-|      Original       |      Coreset       |
-|:-------------------:|:------------------:|
-| ![][PounceOriginal] | ![][PounceCoreset] |
-
-[PounceOriginal]: https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/pounce/pounce.gif
-[PounceCoreset]: https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/pounce/pounce_coreset.gif
-
+|  Original  |  Coreset  |
+|:----------:|:---------:|
+| ![](https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/pounce/pounce.gif) | ![](https://raw.githubusercontent.com/gchq/coreax/refs/heads/main/examples/pounce/pounce_coreset.gif) |
 
 # Setup
 


### PR DESCRIPTION
### PR Type
- Bugfix
- Documentation content changes

### Description
It appears that markdown link aliases `[][LinkName]` do not render correctly in PyPI. This commit replaces the aliases with raw links.

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
