### PR TITLE
chore(docs): remove `np.bool_` nitpick.

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -182,9 +182,6 @@ nitpick_ignore = [
     ("py:class", "jax._src.typing.SupportsDType"),
     ("py:class", "'n d'"),
     ("py:class", "'n p'"),
-    # TODO: Remove once no longer supporting Numpy < 2
-    # https://github.com/gchq/coreax/issues/674
-    ("py:class", "numpy.bool_"),
     ("py:class", "equinox._module.Module"),
     ("py:class", "coreax.coreset._Data"),
     ("py:obj", "coreax.coreset._TPointsData"),


### PR DESCRIPTION
### PR Type
Closes #674.

- Build related changes
- CI related changes

### Description
The `uv.lock` now requires a numpy version greater than 2.0, so we no longer need to ignore this nitpick.


### How Has This Been Tested?
Local documentation builds succeed when using the locked deps.

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
