### PR TITLE
chore(ci): use static matplotlib backend.

### DIFF
--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -83,6 +83,7 @@ minval
 minversion
 mmd
 modindex
+MPLBACKEND
 myst
 nabla
 nanargmax

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,6 +29,9 @@ jobs:
     env:
       # Disable implicitly syncing before running - we run an explicit sync first.
       UV_NO_SYNC: true
+      # Interaction is not required here - use static backend for speed and reliability.
+      # https://matplotlib.org/stable/users/explain/figure/backends.html#static-backends
+      MPLBACKEND: Agg
     steps:
     - uses: actions/checkout@v6
     - name: Set up uv


### PR DESCRIPTION
### PR Type
- Bugfix
- CI related changes
- Tests

### Description
Set Matplotlib backend to `Agg` for the unit tests workflow. Should reduce the integration test time and resolve the flaky tcl based errors on the windows runners.

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
No


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
