### PR TITLE
feat: truncate negative values to zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `KernelThinning.kt_half_recursive` now returns the correct partitions. (https://github.com/gchq/coreax/pull/1088)
 
 ### Changed
+ - `KSD` and `solve_qp` now truncate all negative solutions to zero, rather than using the more complex `apply_negative_precision_threshold` utility to achieve a similar behaviour.
  - `ScoreNetwork` now requires `num_random_vectors` and `num_noise_models` to be provided as positive integers, and requires the `optimiser` to be an `optax.GradientTransformation`.
  - `uv sync --resolution lowest` should now install the lowest supported versions of direct and transitive dependencies
  for all Python versions supported by Coreax. (https://github.com/gchq/coreax/pull/#1092)

--- a/coreax/weights.py
+++ b/coreax/weights.py
@@ -41,7 +41,6 @@ from jaxtyping import Array, Shaped
 
 from coreax.data import Data, as_data
 from coreax.kernels import ScalarValuedKernel
-from coreax.util import apply_negative_precision_threshold
 
 _Data = TypeVar("_Data", bound=Data)
 
@@ -98,7 +97,7 @@ def solve_qp(
     ).params
 
     # Ensure conditions of solution are met
-    solution = apply_negative_precision_threshold(sol.primal, jnp.inf)
+    solution = jnp.maximum(0.0, sol.primal)
     return solution / jnp.sum(solution)
 
 


### PR DESCRIPTION
Closes: #866

### PR Type
- Feature

### Description
Replaces the usages of `apply_negative_precision_threshold`, where appropriate, with the simplified max(0, x).

### How Has This Been Tested?
Existing tests pass as expected.

### Does this PR introduce a breaking change?
No.


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
