### PR TITLE
fix(dependabot): exclude cspell paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      -  ".cspell/"


### PR DESCRIPTION
### PR Type
- Bugfix
- CI related changes

### Description
Should stop Dependabot from trying to update the cspell text files.

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
N/A

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated CHANGELOG.md, if appropriate.
