### PR TITLE
ci: pin actions to commit SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,9 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -27,9 +30,9 @@ jobs:
       percentage_int: ${{ steps.cov.outputs.percentage_int }}
       percentage_float: ${{ steps.cov.outputs.percentage_float }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           version: "latest"
           python-version: 3.13
@@ -48,7 +51,7 @@ jobs:
           cat $GITHUB_OUTPUT
       - name: Check out metadata repo
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: gchq/coreax-metadata
           # GitHub Actions require check out destination to be within coreax/coreax. To
@@ -82,13 +85,13 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
         with:
           app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
           private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}
           repositories: coreax-metadata
       - name: Check out metadata repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: gchq/coreax-metadata
       - name: Generate high-precision coverage JSON

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build documentation
@@ -16,9 +19,9 @@ jobs:
       # Disable implicitly syncing before running - we run an explicit sync first.
       UV_NO_SYNC: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           version: "latest"
           python-version: 3.13

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,9 +30,9 @@ jobs:
       # Disable implicitly syncing before running - we run an explicit sync first.
       UV_NO_SYNC: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           version: "latest"
           python-version: 3.13
@@ -46,7 +46,7 @@ jobs:
         run: uv run tests/performance/run.py --output-file $RUNNER_TEMP/performance.json
       - name: Download historic performance data
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: gchq/coreax-metadata
           # GitHub Actions require check out destination to be within coreax/coreax. To
@@ -74,14 +74,14 @@ jobs:
           cat $RUNNER_TEMP/comment.md
       - name: Upload performance comment artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: performance-comment
           path: ${{ runner.temp }}/comment.md
       - name: Generate a token for saving performance data
         if: github.event_name == 'push'
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
         with:
           app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
           private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}

--- a/.github/workflows/performance_comment.yml
+++ b/.github/workflows/performance_comment.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download performance comment artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: performance-comment
           path: ${{ runner.temp }}/performance-comment
@@ -29,7 +29,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Read performance comment artifact and post/update PR review
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
         with:
           app-id: ${{ vars.WRITE_CONTENTS_PR_APP }}
           private-key: ${{ secrets.WRITE_CONTENTS_PR_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: main
       - name: Create or checkout update branch
@@ -46,7 +46,7 @@ jobs:
 
       # Pre-commit setup and autoupdate steps
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           version: "latest"
           python-version: 3.13

--- a/.github/workflows/pre_commit_checks.yml
+++ b/.github/workflows/pre_commit_checks.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   pre_commit:
     runs-on: ubuntu-latest
@@ -15,9 +18,9 @@ jobs:
       # Disable implicitly syncing before running - we run an explicit sync first.
       UV_NO_SYNC: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           version: "latest"
           python-version: 3.13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,19 @@ on:
         description: Which branch to use to build the release
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.branch }}
       - name: Set up base Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.13
       - name: Install and upgrade build tools
@@ -27,7 +30,7 @@ jobs:
       - name: Build the package
         run: python -m build --verbose --outdir $RUNNER_TEMP/dist
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: build-latest
           path: ${{ runner.temp }}/dist
@@ -62,7 +65,7 @@ jobs:
       UV_NO_SYNC: true
     steps:
       - name: Check out only the test files
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.branch }}
           # Only check out the test files; this ensures we don't get any
@@ -74,7 +77,7 @@ jobs:
           # set to true, it checks out files in the repo root as well.)
           sparse-checkout-cone-mode: false
       - name: Download built package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
          name: build-latest
          path: ${{ runner.temp }}/dist
@@ -93,7 +96,7 @@ jobs:
       - name: Restore uv cache (read-only)
         # We don't save the cache here, as we expect this job to be run only very
         # infrequently.
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}-${{ matrix.python-version }}-test

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -23,6 +23,9 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     strategy:
@@ -48,9 +51,9 @@ jobs:
       # https://matplotlib.org/stable/users/explain/figure/backends.html#static-backends
       MPLBACKEND: Agg
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
       with:
         version: "latest"
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
### PR Type
- CI related changes

### Description
Pin actions to a commit SHA (see https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning to understand the benefits of this) and explicitly state the workflow permissions.

### How Has This Been Tested?
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have ensured my code is easy to understand, including docstrings and comments where necessary.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated CHANGELOG.md, if appropriate.
